### PR TITLE
Add blog post on using Codex

### DIFF
--- a/_posts/2025-06-06-Using-Codex.md
+++ b/_posts/2025-06-06-Using-Codex.md
@@ -1,0 +1,43 @@
+---
+title: "Using Codex to Automate Updates"
+date: 2025-06-06T00:00:00-04:00
+categories:
+  - blog
+  - codex
+---
+
+Codex helps you automate your GitHub workflows with the power of OpenAI models. Below is a short guide for getting started.
+
+## 1. Install Codex
+
+Install Codex globally:
+
+```bash
+npm install -g @openai-labs/codex
+```
+
+## 2. Initialize the Agent
+
+Inside your repository run:
+
+```bash
+npx codex init
+```
+
+This command creates an `AGENTS.md` file where you can provide instructions for the agent about how to work on your codebase.
+
+## 3. Running the Agent
+
+Use Codex to open a shell session in your repository:
+
+```bash
+npx codex shell
+```
+
+From the shell you can tell the agent what you want to do. For example, "add a blog post" or "run tests" and Codex will make the corresponding commits.
+
+## 4. Review Pull Requests
+
+When Codex finishes a task it will craft a pull request summarizing the changes. Review the PR as you would with any human contributor.
+
+This website was updated using Codex!


### PR DESCRIPTION
## Summary
- add new post describing how to use Codex with GitHub workflows

## Testing
- `bundle exec jekyll build` *(fails: `bundler: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_68424c2c6378832eace631b59d690ca7