### PR TITLE
Enable future post rendering

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,6 +13,8 @@ remote_theme: mmistakes/minimal-mistakes
 permalink: /:categories/:title/
 paginate: 5 # amount of posts to show
 paginate_path: /page:num/
+# Build future posts
+future: true
 # timezone: +800
 
 include:


### PR DESCRIPTION
## Summary
- allow Jekyll to build posts with future dates

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6846acfa6168832e80a3babb5f41dc36