### PR TITLE
Add Super AI 2026 EXPO photo gallery

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -5,6 +5,8 @@ main:
     url: /posts/
   - title: "Projects"
     url: /projects/
+  - title: "Gallery"
+    url: /gallery/
   - title: "CV"
     url: /cv/
   - title: "About"

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -345,6 +345,46 @@
   ::selection { background: var(--ink); color: #fff; }
   ::-moz-selection { background: var(--ink); color: #fff; }
 
+  /* ---- Photo gallery (Flickr embeds) -------------------------------- */
+  .expo-gallery {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    gap: 0.75em;
+    margin: 1.75em 0 2.5em;
+  }
+
+  .expo-gallery__item {
+    position: relative;
+    overflow: hidden;
+    border: 1px solid var(--line);
+    border-radius: 6px;
+    background: var(--bg-subtle);
+    aspect-ratio: 3 / 2;
+  }
+
+  /* Fill the tile whether the raw <img> or the embedr-generated markup is shown */
+  .expo-gallery__item img,
+  .expo-gallery__item .flickr-embed-photo,
+  .expo-gallery__item > a,
+  .expo-gallery__item .flickr-embed-container {
+    width: 100% !important;
+    height: 100% !important;
+    display: block;
+  }
+
+  .expo-gallery__item img,
+  .expo-gallery__item .flickr-embed-photo {
+    object-fit: cover;
+    transition: transform 0.4s ease;
+  }
+
+  .expo-gallery__item:hover img,
+  .expo-gallery__item:hover .flickr-embed-photo { transform: scale(1.04); }
+
+  @media (max-width: 600px) {
+    .expo-gallery { grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); }
+  }
+
   /* ---- Responsive --------------------------------------------------- */
   @media (max-width: 768px) {
     .page__content { font-size: 1em; }

--- a/_pages/gallery.md
+++ b/_pages/gallery.md
@@ -1,0 +1,56 @@
+---
+title: "Super AI 2026 EXPO"
+permalink: /gallery/
+layout: single
+author_profile: true
+excerpt: "Photos from the Super AI 2026 EXPO."
+classes: wide
+---
+
+A selection of photos from the **Super AI 2026 EXPO**. Click any image to open the
+full-resolution version on [Flickr](https://www.flickr.com/photos/superai-conf/).
+
+<div class="expo-gallery">
+  <div class="expo-gallery__item">
+    <a data-flickr-embed="true" data-header="false" data-footer="false"
+       href="https://www.flickr.com/photos/superai-conf/55353161389/in/faves-183872530@N03/"
+       title="EXPO-26-00831">
+      <img src="https://live.staticflickr.com/65535/55353161389_9ddb09ba6e_6k.jpg"
+           width="6000" height="4000" alt="EXPO-26-00831" loading="lazy" />
+    </a>
+  </div>
+  <div class="expo-gallery__item">
+    <a data-flickr-embed="true" data-header="false" data-footer="false"
+       href="https://www.flickr.com/photos/superai-conf/55353023356/in/faves-183872530@N03/"
+       title="EXPO-26-00291">
+      <img src="https://live.staticflickr.com/65535/55353023356_09ecc42f41_6k.jpg"
+           width="6144" height="4098" alt="EXPO-26-00291" loading="lazy" />
+    </a>
+  </div>
+  <div class="expo-gallery__item">
+    <a data-flickr-embed="true" data-header="false" data-footer="false"
+       href="https://www.flickr.com/photos/superai-conf/55353242659/in/faves-183872530@N03/"
+       title="EXPO-26-00220">
+      <img src="https://live.staticflickr.com/65535/55353242659_fb4e5884ee_6k.jpg"
+           width="6000" height="4000" alt="EXPO-26-00220" loading="lazy" />
+    </a>
+  </div>
+  <div class="expo-gallery__item">
+    <a data-flickr-embed="true" data-header="false" data-footer="false"
+       href="https://www.flickr.com/photos/superai-conf/55353467170/in/faves-183872530@N03/"
+       title="EXPO-26-00078">
+      <img src="https://live.staticflickr.com/65535/55353467170_f318f6eae9_6k.jpg"
+           width="6144" height="4098" alt="EXPO-26-00078" loading="lazy" />
+    </a>
+  </div>
+  <div class="expo-gallery__item">
+    <a data-flickr-embed="true" data-header="false" data-footer="false"
+       href="https://www.flickr.com/photos/superai-conf/55352949126/in/faves-183872530@N03/"
+       title="EXPO-26-00864">
+      <img src="https://live.staticflickr.com/65535/55352949126_14895a17ba_6k.jpg"
+           width="6000" height="4002" alt="EXPO-26-00864" loading="lazy" />
+    </a>
+  </div>
+</div>
+
+<script async src="//embedr.flickr.com/assets/client-code.js" charset="utf-8"></script>

--- a/_pages/gallery.md
+++ b/_pages/gallery.md
@@ -16,7 +16,7 @@ full-resolution version on [Flickr](https://www.flickr.com/photos/superai-conf/)
        href="https://www.flickr.com/photos/superai-conf/55353161389/in/faves-183872530@N03/"
        title="EXPO-26-00831">
       <img src="https://live.staticflickr.com/65535/55353161389_9ddb09ba6e_6k.jpg"
-           width="6000" height="4000" alt="EXPO-26-00831" loading="lazy" />
+           width="6000" height="4000" alt="Attendees and exhibits at the Super AI 2026 EXPO" loading="lazy" />
     </a>
   </div>
   <div class="expo-gallery__item">
@@ -24,7 +24,7 @@ full-resolution version on [Flickr](https://www.flickr.com/photos/superai-conf/)
        href="https://www.flickr.com/photos/superai-conf/55353023356/in/faves-183872530@N03/"
        title="EXPO-26-00291">
       <img src="https://live.staticflickr.com/65535/55353023356_09ecc42f41_6k.jpg"
-           width="6144" height="4098" alt="EXPO-26-00291" loading="lazy" />
+           width="6144" height="4098" alt="Conference floor at the Super AI 2026 EXPO" loading="lazy" />
     </a>
   </div>
   <div class="expo-gallery__item">
@@ -32,7 +32,7 @@ full-resolution version on [Flickr](https://www.flickr.com/photos/superai-conf/)
        href="https://www.flickr.com/photos/superai-conf/55353242659/in/faves-183872530@N03/"
        title="EXPO-26-00220">
       <img src="https://live.staticflickr.com/65535/55353242659_fb4e5884ee_6k.jpg"
-           width="6000" height="4000" alt="EXPO-26-00220" loading="lazy" />
+           width="6000" height="4000" alt="Exhibition booth at the Super AI 2026 EXPO" loading="lazy" />
     </a>
   </div>
   <div class="expo-gallery__item">
@@ -40,7 +40,7 @@ full-resolution version on [Flickr](https://www.flickr.com/photos/superai-conf/)
        href="https://www.flickr.com/photos/superai-conf/55353467170/in/faves-183872530@N03/"
        title="EXPO-26-00078">
       <img src="https://live.staticflickr.com/65535/55353467170_f318f6eae9_6k.jpg"
-           width="6144" height="4098" alt="EXPO-26-00078" loading="lazy" />
+           width="6144" height="4098" alt="Presentation stage at the Super AI 2026 EXPO" loading="lazy" />
     </a>
   </div>
   <div class="expo-gallery__item">
@@ -48,9 +48,9 @@ full-resolution version on [Flickr](https://www.flickr.com/photos/superai-conf/)
        href="https://www.flickr.com/photos/superai-conf/55352949126/in/faves-183872530@N03/"
        title="EXPO-26-00864">
       <img src="https://live.staticflickr.com/65535/55352949126_14895a17ba_6k.jpg"
-           width="6000" height="4002" alt="EXPO-26-00864" loading="lazy" />
+           width="6000" height="4002" alt="Crowd at the Super AI 2026 EXPO" loading="lazy" />
     </a>
   </div>
 </div>
 
-<script async src="//embedr.flickr.com/assets/client-code.js" charset="utf-8"></script>
+<script async src="https://embedr.flickr.com/assets/client-code.js" charset="utf-8"></script>


### PR DESCRIPTION
## Why

Adds a new photo gallery page to showcase personal photos from the Super AI 2026 EXPO, giving the site a dedicated visual section linked from the main navigation.

## What

- **New `/gallery/` page** (`_pages/gallery.md`) presenting the 5 EXPO photos in a responsive grid, each clicking through to the original on Flickr.
- **Navigation** (`_data/navigation.yml`): added a "Gallery" item between Projects and CV.
- **Styling** (`_includes/head/custom.html`): minimalist gallery CSS with uniform 3:2 tiles and a subtle hover zoom, matching the existing theme.

## Notes for reviewers

I originally planned lightweight reconstructed thumbnail URLs (`_c`/`_k`) with a custom lightbox, but testing showed those sizes return **410 Gone** because the photo owner restricted all standard sizes; only the original-secret `_6k` URLs resolve. To avoid loading five multi-MB 6K originals directly, the page uses Flickr's official embed (`data-flickr-embed` + the `embedr` client script), which lazy-loads a properly sized responsive image and handles click-through. I verified both the Flickr photo pages and the embed script return 200.

Local Jekyll build was not run because Ruby/Jekyll is not installed in this environment; the changes follow standard Jekyll / Minimal Mistakes conventions.