### PR TITLE
Deploy CV/site control refinements

### DIFF
--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -9,7 +9,7 @@
      (Inter) and a monospace for code / geeky accents (JetBrains Mono). -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Noto+Sans+SC:wght@400;500;700&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
 
 <!-- Set theme early to avoid a flash of the wrong palette -->
 <script>
@@ -17,11 +17,9 @@
     try {
       var t = localStorage.getItem('xw-theme') || (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
       var a = localStorage.getItem('xw-accent') || 'graphite';
-      var l = localStorage.getItem('xw-lang') || 'en';
       var r = document.documentElement;
       r.setAttribute('data-theme', t);
       r.setAttribute('data-accent', a);
-      r.setAttribute('data-lang', l);
     } catch (e) {}
   })();
 </script>
@@ -51,8 +49,8 @@
     --accent-soft:     rgba(26, 26, 26, 0.08);
     --accent-underline: #c9c9cd;
 
-    --font-body: "Inter", "Noto Sans SC", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-    --font-display: "Space Grotesk", "Inter", "Noto Sans SC", sans-serif;
+    --font-body: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    --font-display: "Space Grotesk", "Inter", sans-serif;
     --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
 
     --shadow-card: 0 1px 2px rgba(0,0,0,0.04), 0 8px 24px rgba(0,0,0,0.06);
@@ -102,8 +100,6 @@
     -moz-osx-font-smoothing: grayscale;
     transition: background-color 0.25s ease, color 0.25s ease;
   }
-
-  [data-lang="zh"] body { --font-body: "Noto Sans SC", "Inter", sans-serif; }
 
   /* ---- Masthead (top navigation) ------------------------------------ */
   .masthead {
@@ -329,28 +325,27 @@
   @media (max-width: 600px) { .expo-gallery { grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); } }
 
   /* =====================================================================
-     Floating control dock (theme / accent / language)
+     Header settings control (theme + accent), mounted in the masthead
      ===================================================================== */
-  .xw-dock { position: fixed; right: 1.1rem; bottom: 1.1rem; z-index: 9999; font-family: var(--font-body); }
-  .xw-dock__toggle {
-    width: 46px; height: 46px; border-radius: 50%;
-    display: flex; align-items: center; justify-content: center;
-    background: var(--accent); color: var(--accent-contrast);
-    border: 0; cursor: pointer; box-shadow: var(--shadow-card);
-    font-size: 1.15rem; line-height: 1; transition: transform 0.2s ease;
+  .xw-settings { position: relative; display: flex; align-items: center; margin-left: auto; }
+  .xw-settings__btn {
+    width: 38px; height: 38px; border-radius: 8px; display: flex; align-items: center; justify-content: center;
+    background: transparent; color: var(--ink-soft); border: 1px solid transparent; cursor: pointer;
+    font-size: 1.05rem; line-height: 1; transition: color 0.15s ease, background 0.15s ease, border-color 0.15s ease;
   }
-  .xw-dock__toggle:hover { transform: rotate(30deg) scale(1.05); }
-  .xw-dock__panel {
-    position: absolute; right: 0; bottom: 58px; width: 232px;
+  .xw-settings__btn:hover,
+  .xw-settings.open .xw-settings__btn { color: var(--ink); background: var(--bg-subtle); border-color: var(--line); }
+  .xw-settings__panel {
+    position: absolute; top: calc(100% + 10px); right: 0; width: 232px;
     background: var(--bg-elev); border: 1px solid var(--line); border-radius: 12px;
-    box-shadow: var(--shadow-card); padding: 0.9rem; opacity: 0; visibility: hidden;
-    transform: translateY(8px) scale(0.98); transform-origin: bottom right;
-    transition: opacity 0.18s ease, transform 0.18s ease, visibility 0.18s;
+    box-shadow: var(--shadow-card); padding: 0.9rem; z-index: 1000;
+    opacity: 0; visibility: hidden; transform: translateY(-6px) scale(0.98); transform-origin: top right;
+    transition: opacity 0.16s ease, transform 0.16s ease, visibility 0.16s;
   }
-  .xw-dock.open .xw-dock__panel { opacity: 1; visibility: visible; transform: translateY(0) scale(1); }
-  .xw-dock__group { margin-bottom: 0.85rem; }
-  .xw-dock__group:last-child { margin-bottom: 0; }
-  .xw-dock__label {
+  .xw-settings.open .xw-settings__panel { opacity: 1; visibility: visible; transform: translateY(0) scale(1); }
+  .xw-group { margin-bottom: 0.85rem; }
+  .xw-group:last-child { margin-bottom: 0; }
+  .xw-group__label {
     font-family: var(--font-mono); font-size: 0.62rem; letter-spacing: 0.12em; text-transform: uppercase;
     color: var(--ink-faint); margin-bottom: 0.45rem; display: block;
   }
@@ -371,7 +366,7 @@
   .xw-swatch[aria-pressed="true"]:after {
     content: ""; position: absolute; inset: -5px; border-radius: 50%; border: 1px solid var(--accent);
   }
-  @media (max-width: 600px) { .xw-dock { right: 0.7rem; bottom: 0.7rem; } }
+  @media (max-width: 600px) { .xw-settings__panel { right: -0.25rem; } }
 
   /* =====================================================================
      CV page — custom "geek-professional" layout
@@ -412,9 +407,13 @@
     font-size: 0.86rem; padding: 0.55rem 1rem; border-radius: 8px; text-decoration: none; transition: all 0.15s ease;
     border: 1px solid var(--line);
   }
-  .cv-btn--solid { background: var(--accent); color: var(--accent-contrast); border-color: var(--accent); }
-  .cv-btn--solid:hover { background: var(--accent-strong); border-color: var(--accent-strong); transform: translateY(-1px); }
+  /* Primary (GitHub): always high-contrast and legible regardless of accent/theme */
+  .cv-btn--solid { background: var(--ink); color: var(--bg); border-color: var(--ink); }
+  .cv-btn--solid i { color: var(--bg); }
+  .cv-btn--solid:hover { background: var(--accent); color: var(--accent-contrast); border-color: var(--accent); transform: translateY(-1px); }
+  .cv-btn--solid:hover i { color: var(--accent-contrast); }
   .cv-btn--ghost { background: transparent; color: var(--ink); }
+  .cv-btn--ghost i { color: var(--accent); }
   .cv-btn--ghost:hover { border-color: var(--accent); color: var(--accent); transform: translateY(-1px); }
 
   /* Section headers */
@@ -445,22 +444,6 @@
   }
   .cv-tag:hover { background: var(--accent-soft); border-color: var(--accent); color: var(--accent); }
 
-  /* Project cards */
-  .cv-projects { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem; }
-  .cv-proj {
-    display: flex; flex-direction: column; background: var(--bg-elev); border: 1px solid var(--line);
-    border-radius: 12px; padding: 1.25rem; text-decoration: none; transition: border-color 0.15s ease, transform 0.15s ease, box-shadow 0.15s ease;
-  }
-  .cv-proj:hover { border-color: var(--accent); transform: translateY(-3px); box-shadow: var(--shadow-card); }
-  .cv-proj__top { display: flex; align-items: center; justify-content: space-between; margin-bottom: 0.7rem; }
-  .cv-proj__name { font-family: var(--font-mono); font-size: 0.95rem; font-weight: 600; color: var(--ink); }
-  .cv-proj__name i { color: var(--accent); margin-right: 0.4em; }
-  .cv-proj__arrow { color: var(--ink-faint); transition: transform 0.15s ease, color 0.15s ease; }
-  .cv-proj:hover .cv-proj__arrow { color: var(--accent); transform: translate(2px, -2px); }
-  .cv-proj__desc { color: var(--ink-soft); font-size: 0.9rem; line-height: 1.6; margin-bottom: 0.9rem; flex: 1; }
-  .cv-proj__stack { display: flex; flex-wrap: wrap; gap: 0.35rem; }
-  .cv-proj__lang { font-family: var(--font-mono); font-size: 0.68rem; color: var(--ink-faint); background: var(--bg-subtle); border: 1px solid var(--line); border-radius: 4px; padding: 0.12rem 0.4rem; }
-
   /* Focus / expertise list */
   .cv-focus { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 0.6rem 1.6rem; }
   .cv-focus__item {
@@ -469,13 +452,6 @@
   }
   .cv-focus__item i { color: var(--accent); margin-top: 0.2rem; }
   .cv-focus__item b { color: var(--ink); font-weight: 600; }
-
-  /* Owner note */
-  .cv-note {
-    background: var(--bg-subtle); border: 1px dashed var(--line); border-radius: 10px; padding: 1rem 1.2rem;
-    font-family: var(--font-mono); font-size: 0.8rem; color: var(--ink-faint); line-height: 1.6;
-  }
-  .cv-note b { color: var(--ink-soft); }
 
   /* Contact */
   .cv-contact { display: flex; flex-wrap: wrap; gap: 0.7rem; }
@@ -502,49 +478,19 @@
 
 <script>
   /* =====================================================================
-     Theme controller, accent picker, and English/Chinese i18n
+     Theme controller + accent picker, mounted into the masthead headline
      ===================================================================== */
   (function () {
     var root = document.documentElement;
-    var STORE = { theme: 'xw-theme', accent: 'xw-accent', lang: 'xw-lang' };
+    var STORE = { theme: 'xw-theme', accent: 'xw-accent' };
 
     function get(key, fallback) { try { return localStorage.getItem(key) || fallback; } catch (e) { return fallback; } }
     function set(key, val) { try { localStorage.setItem(key, val); } catch (e) {} }
 
     var state = {
       theme:  get(STORE.theme, root.getAttribute('data-theme') || 'light'),
-      accent: get(STORE.accent, 'graphite'),
-      lang:   get(STORE.lang, 'en')
+      accent: get(STORE.accent, 'graphite')
     };
-
-    /* ---- i18n: nav labels + UI chrome -------------------------------- */
-    var NAV = {
-      'Home':     { en: 'Home',     zh: '首页' },
-      'Posts':    { en: 'Posts',    zh: '文章' },
-      'Projects': { en: 'Projects', zh: '项目' },
-      'Gallery':  { en: 'Gallery',  zh: '相册' },
-      'CV':       { en: 'CV',       zh: '简历' },
-      'About':    { en: 'About',    zh: '关于' }
-    };
-
-    function applyLang(lang) {
-      root.setAttribute('data-lang', lang);
-      document.documentElement.lang = (lang === 'zh') ? 'zh-CN' : 'en';
-
-      /* Navigation links */
-      var links = document.querySelectorAll('.greedy-nav .visible-links a, .greedy-nav .hidden-links a');
-      links.forEach(function (a) {
-        var key = a.getAttribute('data-nav-key');
-        if (!key) { key = a.textContent.trim(); a.setAttribute('data-nav-key', key); }
-        if (NAV[key]) a.textContent = NAV[key][lang];
-      });
-
-      /* Any element opted into translation via data-i18n-en / data-i18n-zh */
-      document.querySelectorAll('[data-i18n-en]').forEach(function (el) {
-        var val = el.getAttribute('data-i18n-' + lang);
-        if (val !== null && val !== undefined) el.textContent = val;
-      });
-    }
 
     function applyTheme(t) { root.setAttribute('data-theme', t); }
     function applyAccent(a) { root.setAttribute('data-accent', a); }
@@ -552,7 +498,6 @@
     applyTheme(state.theme);
     applyAccent(state.accent);
 
-    /* ---- Build the floating control dock ----------------------------- */
     var ACCENTS = [
       { id: 'graphite', color: '#5b5b5b' },
       { id: 'blue',     color: '#2563eb' },
@@ -562,54 +507,41 @@
       { id: 'rose',     color: '#e11d48' }
     ];
 
-    var UI = {
-      appearance: { en: 'Appearance', zh: '外观' },
-      light:      { en: 'Light',      zh: '浅色' },
-      dark:       { en: 'Dark',       zh: '深色' },
-      accent:     { en: 'Accent',     zh: '主题色' },
-      language:   { en: 'Language',   zh: '语言' }
-    };
+    function buildSettings() {
+      var host = document.querySelector('.greedy-nav') ||
+                 document.querySelector('.masthead__inner-wrap') ||
+                 document.body;
 
-    function buildDock() {
-      var dock = document.createElement('div');
-      dock.className = 'xw-dock';
-      dock.innerHTML =
-        '<button class="xw-dock__toggle" aria-label="Site settings" aria-expanded="false">&#9881;</button>' +
-        '<div class="xw-dock__panel" role="dialog" aria-label="Site settings">' +
-          '<div class="xw-dock__group">' +
-            '<span class="xw-dock__label" data-ui="appearance"></span>' +
+      var wrap = document.createElement('div');
+      wrap.className = 'xw-settings';
+      wrap.innerHTML =
+        '<button class="xw-settings__btn" aria-label="Site settings" aria-expanded="false" title="Theme settings">&#9881;</button>' +
+        '<div class="xw-settings__panel" role="dialog" aria-label="Site settings">' +
+          '<div class="xw-group">' +
+            '<span class="xw-group__label">Appearance</span>' +
             '<div class="xw-seg" data-role="theme">' +
-              '<button data-val="light" aria-pressed="false"><span>&#9728;</span><span data-ui="light"></span></button>' +
-              '<button data-val="dark" aria-pressed="false"><span>&#9789;</span><span data-ui="dark"></span></button>' +
+              '<button data-val="light" aria-pressed="false"><span>&#9728;</span><span>Light</span></button>' +
+              '<button data-val="dark" aria-pressed="false"><span>&#9789;</span><span>Dark</span></button>' +
             '</div>' +
           '</div>' +
-          '<div class="xw-dock__group">' +
-            '<span class="xw-dock__label" data-ui="accent"></span>' +
+          '<div class="xw-group">' +
+            '<span class="xw-group__label">Accent</span>' +
             '<div class="xw-swatches" data-role="accent"></div>' +
           '</div>' +
-          '<div class="xw-dock__group">' +
-            '<span class="xw-dock__label" data-ui="language"></span>' +
-            '<div class="xw-seg" data-role="lang">' +
-              '<button data-val="en" aria-pressed="false">EN</button>' +
-              '<button data-val="zh" aria-pressed="false">&#20013;&#25991;</button>' +
-            '</div>' +
-          '</div>' +
         '</div>';
-      document.body.appendChild(dock);
+      host.appendChild(wrap);
 
-      var toggle = dock.querySelector('.xw-dock__toggle');
-      var panel = dock.querySelector('.xw-dock__panel');
-      toggle.addEventListener('click', function (e) {
+      var btn = wrap.querySelector('.xw-settings__btn');
+      btn.addEventListener('click', function (e) {
         e.stopPropagation();
-        var open = dock.classList.toggle('open');
-        toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+        var open = wrap.classList.toggle('open');
+        btn.setAttribute('aria-expanded', open ? 'true' : 'false');
       });
       document.addEventListener('click', function (e) {
-        if (!dock.contains(e.target)) { dock.classList.remove('open'); toggle.setAttribute('aria-expanded', 'false'); }
+        if (!wrap.contains(e.target)) { wrap.classList.remove('open'); btn.setAttribute('aria-expanded', 'false'); }
       });
 
-      /* Accent swatches */
-      var swWrap = dock.querySelector('[data-role="accent"]');
+      var swWrap = wrap.querySelector('[data-role="accent"]');
       ACCENTS.forEach(function (a) {
         var b = document.createElement('button');
         b.className = 'xw-swatch';
@@ -620,49 +552,30 @@
         swWrap.appendChild(b);
       });
 
-      /* Sync pressed states */
       function sync() {
-        dock.querySelectorAll('[data-role="theme"] button').forEach(function (b) {
+        wrap.querySelectorAll('[data-role="theme"] button').forEach(function (b) {
           b.setAttribute('aria-pressed', b.getAttribute('data-val') === state.theme ? 'true' : 'false');
         });
-        dock.querySelectorAll('[data-role="lang"] button').forEach(function (b) {
-          b.setAttribute('aria-pressed', b.getAttribute('data-val') === state.lang ? 'true' : 'false');
-        });
-        dock.querySelectorAll('[data-role="accent"] button').forEach(function (b) {
+        wrap.querySelectorAll('[data-role="accent"] button').forEach(function (b) {
           b.setAttribute('aria-pressed', b.getAttribute('data-val') === state.accent ? 'true' : 'false');
         });
       }
 
-      function labelDock(lang) {
-        dock.querySelectorAll('[data-ui]').forEach(function (el) {
-          var k = el.getAttribute('data-ui');
-          if (UI[k]) el.textContent = UI[k][lang];
-        });
-        toggle.setAttribute('aria-label', UI.appearance[lang] === undefined ? 'Settings' : (lang === 'zh' ? '设置' : 'Settings'));
-      }
-
-      dock.querySelector('[data-role="theme"]').addEventListener('click', function (e) {
+      wrap.querySelector('[data-role="theme"]').addEventListener('click', function (e) {
         var b = e.target.closest('button'); if (!b) return;
         state.theme = b.getAttribute('data-val'); set(STORE.theme, state.theme); applyTheme(state.theme); sync();
-      });
-      dock.querySelector('[data-role="lang"]').addEventListener('click', function (e) {
-        var b = e.target.closest('button'); if (!b) return;
-        state.lang = b.getAttribute('data-val'); set(STORE.lang, state.lang); applyLang(state.lang); labelDock(state.lang); sync();
       });
       swWrap.addEventListener('click', function (e) {
         var b = e.target.closest('button'); if (!b) return;
         state.accent = b.getAttribute('data-val'); set(STORE.accent, state.accent); applyAccent(state.accent); sync();
       });
 
-      labelDock(state.lang);
       sync();
     }
 
-    /* ---- Boot -------------------------------------------------------- */
     function boot() {
       if (/^\/cv\/?$/.test(location.pathname)) document.body.classList.add('is-cv');
-      applyLang(state.lang);
-      buildDock();
+      buildSettings();
     }
 
     if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', boot);

--- a/_includes/head/custom.html
+++ b/_includes/head/custom.html
@@ -5,83 +5,135 @@
   <script defer data-domain="{{ site.analytics.plausible.domain }}" src="https://plausible.io/js/plausible.js"></script>
 {% endif %}
 
-<!-- Fonts: a single, clean typeface for a minimalist reading experience -->
+<!-- Fonts: a display face for headings (Space Grotesk), a workhorse UI/body face
+     (Inter) and a monospace for code / geeky accents (JetBrains Mono). -->
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Noto+Sans+SC:wght@400;500;700&display=swap" rel="stylesheet">
 
-<!--
-  Minimalist theme overrides.
-  Philosophy: as simple as possible, but not simpler.
-  - One neutral ink colour, one restrained accent, lots of whitespace.
-  - No gradients, no heavy shadows, no decorative hover animations.
-  - Content-first typography with a comfortable reading measure.
--->
+<!-- Set theme early to avoid a flash of the wrong palette -->
+<script>
+  (function () {
+    try {
+      var t = localStorage.getItem('xw-theme') || (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+      var a = localStorage.getItem('xw-accent') || 'graphite';
+      var l = localStorage.getItem('xw-lang') || 'en';
+      var r = document.documentElement;
+      r.setAttribute('data-theme', t);
+      r.setAttribute('data-accent', a);
+      r.setAttribute('data-lang', l);
+    } catch (e) {}
+  })();
+</script>
+
 <style>
+  /* =====================================================================
+     Design tokens
+     ---------------------------------------------------------------------
+     Philosophy: minimalist, content-first, "geek-professional".
+     One tunable accent, a coherent dark mode, generous whitespace.
+     ===================================================================== */
   :root {
     --ink:        #1a1a1a;   /* primary text            */
     --ink-soft:   #55565a;   /* secondary text          */
     --ink-faint:  #8a8b90;   /* meta / captions         */
     --line:       #e7e7e9;   /* hairlines / borders     */
+    --line-soft:  #f0f0f2;
     --bg:         #ffffff;   /* page background         */
     --bg-subtle:  #fafafa;   /* code / quiet surfaces   */
-    --accent:     #1a1a1a;   /* links (monochrome)      */
+    --bg-elev:    #ffffff;   /* raised cards            */
+    --hero-bg:    #101216;   /* splash hero (stays dark)*/
+
+    /* Accent (overridden by [data-accent]) — default is monochrome graphite */
+    --accent:          #1a1a1a;
+    --accent-strong:   #000000;
+    --accent-contrast: #ffffff;
+    --accent-soft:     rgba(26, 26, 26, 0.08);
     --accent-underline: #c9c9cd;
+
+    --font-body: "Inter", "Noto Sans SC", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    --font-display: "Space Grotesk", "Inter", "Noto Sans SC", sans-serif;
+    --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+
+    --shadow-card: 0 1px 2px rgba(0,0,0,0.04), 0 8px 24px rgba(0,0,0,0.06);
   }
 
-  /* ---- Base ---------------------------------------------------------- */
+  [data-theme="dark"] {
+    --ink:        #e6edf3;
+    --ink-soft:   #b1bac4;
+    --ink-faint:  #7d8590;
+    --line:       #2a2f37;
+    --line-soft:  #21262d;
+    --bg:         #0d1117;
+    --bg-subtle:  #161b22;
+    --bg-elev:    #161b22;
+    --accent:          #e6edf3;
+    --accent-strong:   #ffffff;
+    --accent-contrast: #0d1117;
+    --accent-soft:     rgba(230, 237, 243, 0.10);
+    --accent-underline: #3a414b;
+    --shadow-card: 0 1px 2px rgba(0,0,0,0.4), 0 12px 32px rgba(0,0,0,0.45);
+  }
+
+  /* ---- Accent themes (independent of light/dark) --------------------- */
+  [data-accent="blue"]    { --accent:#2563eb; --accent-strong:#1d4ed8; --accent-contrast:#fff; --accent-soft:rgba(37,99,235,.10);  --accent-underline:#a9c2f6; }
+  [data-accent="emerald"] { --accent:#059669; --accent-strong:#047857; --accent-contrast:#fff; --accent-soft:rgba(5,150,105,.10);  --accent-underline:#9fdcc5; }
+  [data-accent="violet"]  { --accent:#7c3aed; --accent-strong:#6d28d9; --accent-contrast:#fff; --accent-soft:rgba(124,58,237,.10); --accent-underline:#cbb4f4; }
+  [data-accent="amber"]   { --accent:#d97706; --accent-strong:#b45309; --accent-contrast:#fff; --accent-soft:rgba(217,119,6,.12);  --accent-underline:#f0cd93; }
+  [data-accent="rose"]    { --accent:#e11d48; --accent-strong:#be123c; --accent-contrast:#fff; --accent-soft:rgba(225,29,72,.10);  --accent-underline:#f4a9ba; }
+
+  /* Brighter accents on dark backgrounds for contrast */
+  [data-theme="dark"][data-accent="blue"]    { --accent:#4d94ff; --accent-underline:#274b7a; }
+  [data-theme="dark"][data-accent="emerald"] { --accent:#2ecc8f; --accent-underline:#1f5641; }
+  [data-theme="dark"][data-accent="violet"]  { --accent:#a97bf7; --accent-underline:#4a3277; }
+  [data-theme="dark"][data-accent="amber"]   { --accent:#f0a838; --accent-underline:#6b4a1a; }
+  [data-theme="dark"][data-accent="rose"]    { --accent:#f2537a; --accent-underline:#742638; }
+
+  /* =====================================================================
+     Base
+     ===================================================================== */
   html { scroll-behavior: smooth; }
 
   body {
     color: var(--ink);
-    background: var(--bg);
-    font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+    background: var(--bg) !important;
+    font-family: var(--font-body);
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
+    transition: background-color 0.25s ease, color 0.25s ease;
   }
+
+  [data-lang="zh"] body { --font-body: "Noto Sans SC", "Inter", sans-serif; }
 
   /* ---- Masthead (top navigation) ------------------------------------ */
   .masthead {
     border-bottom: 1px solid var(--line);
     box-shadow: none;
+    background: var(--bg);
   }
-
   .masthead__inner-wrap { padding: 1.1em 1em; }
-
   .site-title {
+    font-family: var(--font-display);
     font-weight: 600;
     font-size: 1.05em;
     letter-spacing: -0.01em;
     color: var(--ink) !important;
   }
-
   .site-subtitle { color: var(--ink-faint); font-weight: 400; }
-
   .greedy-nav { background: transparent; }
-
   .greedy-nav a,
-  .greedy-nav .visible-links a {
-    color: var(--ink-soft);
-    font-weight: 500;
-    transition: color 0.15s ease;
-  }
-
+  .greedy-nav .visible-links a { color: var(--ink-soft); font-weight: 500; transition: color 0.15s ease; }
   .greedy-nav a:hover,
   .greedy-nav .visible-links a:hover { color: var(--ink); opacity: 1; }
-
-  .greedy-nav .visible-links a:before { background: var(--ink); height: 2px; }
-
-  .greedy-nav .hidden-links {
-    background: var(--bg);
-    border: 1px solid var(--line);
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.06);
-  }
-
+  .greedy-nav .visible-links a:before { background: var(--accent); height: 2px; }
+  .greedy-nav .hidden-links { background: var(--bg-elev); border: 1px solid var(--line); box-shadow: var(--shadow-card); }
   .greedy-nav .hidden-links a { color: var(--ink-soft); }
+  .greedy-nav .hidden-links a:hover { background: var(--bg-subtle); color: var(--ink); }
   .greedy-nav button { background: transparent; color: var(--ink); }
 
   /* ---- Page titles & headings --------------------------------------- */
   .page__title {
+    font-family: var(--font-display);
     color: var(--ink);
     font-weight: 700;
     letter-spacing: -0.02em;
@@ -89,17 +141,9 @@
     margin-top: 0;
     margin-bottom: 0.5em;
   }
-
-  .page__lead,
-  .page__meta,
-  .archive__subtitle { color: var(--ink-soft); font-weight: 400; }
-
-  .page__content {
-    font-size: 1.05em;
-    line-height: 1.75;
-    color: var(--ink);
-  }
-
+  .page__lead, .page__meta, .archive__subtitle { color: var(--ink-soft); font-weight: 400; }
+  .page__content { font-size: 1.05em; line-height: 1.75; color: var(--ink); }
+  .page__content h1, .page__content h2, .page__content h3 { font-family: var(--font-display); }
   .page__content h2 {
     color: var(--ink);
     font-weight: 600;
@@ -109,16 +153,8 @@
     padding-bottom: 0.35em;
     border-bottom: 1px solid var(--line);
   }
-
-  .page__content h3 {
-    color: var(--ink);
-    font-weight: 600;
-    margin-top: 1.6em;
-    margin-bottom: 0.6em;
-  }
-
+  .page__content h3 { color: var(--ink); font-weight: 600; margin-top: 1.6em; margin-bottom: 0.6em; }
   .page__content h4 { color: var(--ink-soft); font-weight: 600; }
-
   .page__content p  { margin-bottom: 1.25em; }
   .page__content ul, .page__content ol { margin-bottom: 1.4em; }
   .page__content li { margin-bottom: 0.4em; }
@@ -128,17 +164,13 @@
     color: var(--accent);
     text-decoration: none;
     border-bottom: 1px solid var(--accent-underline);
-    transition: border-color 0.15s ease;
+    transition: border-color 0.15s ease, color 0.15s ease;
   }
-
-  .page__content a:not(.btn):hover {
-    color: var(--ink);
-    border-bottom-color: var(--ink);
-  }
+  .page__content a:not(.btn):hover { color: var(--accent-strong); border-bottom-color: var(--accent); }
 
   /* ---- Blockquotes -------------------------------------------------- */
   .page__content blockquote {
-    border-left: 2px solid var(--ink);
+    border-left: 2px solid var(--accent);
     margin-left: 0;
     padding: 0.1em 0 0.1em 1.25em;
     font-style: normal;
@@ -148,241 +180,316 @@
   }
 
   /* ---- Code --------------------------------------------------------- */
-  .page__content code,
-  code, tt {
-    font-family: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  .page__content code, code, tt {
+    font-family: var(--font-mono);
     font-size: 0.88em;
     background: var(--bg-subtle);
     border: 1px solid var(--line);
     border-radius: 4px;
     padding: 0.12em 0.4em;
-  }
-
-  div.highlighter-rouge, figure.highlight, pre.highlight {
-    border-radius: 6px;
-  }
-
-  .page__content pre code,
-  .highlight code { border: 0; background: transparent; padding: 0; }
-
-  /* ---- Buttons: flat, outlined, minimal ----------------------------- */
-  .btn {
-    border-radius: 4px;
-    font-weight: 500;
-    box-shadow: none;
-    transition: background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease;
-  }
-
-  .btn--primary,
-  .btn--info {
-    background-color: var(--ink);
-    border: 1px solid var(--ink);
-    color: #fff;
-    box-shadow: none;
-  }
-
-  .btn--primary:hover,
-  .btn--info:hover {
-    background-color: #000;
-    border-color: #000;
-    color: #fff;
-    transform: none;
-    box-shadow: none;
-  }
-
-  .btn--light-outline {
-    border: 1px solid rgba(255, 255, 255, 0.85);
-    color: #fff;
-  }
-
-  .btn--light-outline:hover { background: #fff; color: var(--ink); }
-
-  /* ---- Author profile sidebar --------------------------------------- */
-  .author__avatar img {
-    border: 1px solid var(--line);
-    border-radius: 50%;
-    box-shadow: none;
-  }
-
-  .author__name { font-weight: 600; color: var(--ink); }
-  .author__bio  { color: var(--ink-soft); line-height: 1.6; }
-
-  .author__urls-wrapper button {
-    background: transparent;
-    border: 1px solid var(--line);
     color: var(--ink);
   }
+  div.highlighter-rouge, figure.highlight, pre.highlight { border-radius: 6px; }
+  .page__content pre code, .highlight code { border: 0; background: transparent; padding: 0; }
 
-  .author__urls.social-icons a { color: var(--ink-soft); }
-  .author__urls.social-icons a:hover { color: var(--ink); }
-  .author__urls.social-icons i { color: inherit; }
-
-  /* ---- Table of contents: flat, unobtrusive ------------------------- */
-  .toc {
-    background: transparent;
-    border: 1px solid var(--line);
+  /* ---- Buttons: flat, accent-aware ---------------------------------- */
+  .btn {
     border-radius: 6px;
+    font-weight: 500;
+    box-shadow: none;
+    transition: background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease, transform 0.15s ease;
+  }
+  .btn--primary, .btn--info {
+    background-color: var(--accent);
+    border: 1px solid var(--accent);
+    color: var(--accent-contrast);
     box-shadow: none;
   }
+  .btn--primary:hover, .btn--info:hover {
+    background-color: var(--accent-strong);
+    border-color: var(--accent-strong);
+    color: var(--accent-contrast);
+    transform: translateY(-1px);
+    box-shadow: none;
+  }
+  .btn--light-outline { border: 1px solid rgba(255, 255, 255, 0.85); color: #fff; }
+  .btn--light-outline:hover { background: #fff; color: #101216; }
 
+  /* ---- Author profile sidebar --------------------------------------- */
+  .sidebar, .author__urls-wrapper { color: var(--ink-soft); }
+  .author__avatar img { border: 1px solid var(--line); border-radius: 50%; box-shadow: none; }
+  .author__name { font-family: var(--font-display); font-weight: 600; color: var(--ink); }
+  .author__bio  { color: var(--ink-soft); line-height: 1.6; }
+  .author__urls-wrapper button { background: transparent; border: 1px solid var(--line); color: var(--ink); }
+  .author__urls { background: var(--bg-elev); border: 1px solid var(--line); box-shadow: var(--shadow-card); }
+  [data-theme="dark"] .author__urls:before { border-bottom-color: var(--line); }
+  .author__urls li { border-bottom: 1px solid var(--line-soft); }
+  .author__urls.social-icons a { color: var(--ink-soft); }
+  .author__urls.social-icons a:hover { color: var(--accent); }
+  .author__urls.social-icons i { color: inherit; }
+
+  /* ---- Table of contents -------------------------------------------- */
+  .toc { background: var(--bg-elev); border: 1px solid var(--line); border-radius: 6px; box-shadow: none; }
   .toc .nav__title {
-    background: transparent;
-    color: var(--ink-faint);
-    font-weight: 600;
-    text-transform: uppercase;
-    font-size: 0.72em;
-    letter-spacing: 0.08em;
+    background: var(--accent); color: var(--accent-contrast);
+    font-weight: 600; text-transform: uppercase; font-size: 0.72em; letter-spacing: 0.08em;
   }
-
-  .toc__menu a {
-    color: var(--ink-soft);
-    font-size: 0.82em;
-    border-left: 2px solid transparent;
-    transition: color 0.15s ease, border-color 0.15s ease;
-  }
-
-  .toc__menu a:hover { color: var(--ink); }
-  .toc__menu a.active { color: var(--ink); font-weight: 500; border-left-color: var(--ink); }
+  .toc__menu a { color: var(--ink-soft); font-size: 0.82em; border-left: 2px solid transparent; transition: color 0.15s ease, border-color 0.15s ease; }
+  .toc__menu a:hover { color: var(--ink); background: var(--bg-subtle); }
+  .toc__menu a.active { color: var(--accent); font-weight: 500; border-left-color: var(--accent); background: var(--accent-soft); }
 
   /* ---- Hero header (splash / overlay) ------------------------------- */
   .page__hero--overlay {
     padding: 6em 0;
-    background-color: var(--ink);
+    background-color: var(--hero-bg) !important;
+    background-image:
+      radial-gradient(600px circle at 20% 15%, rgba(255,255,255,0.06), transparent 45%),
+      linear-gradient(180deg, rgba(255,255,255,0.02), rgba(0,0,0,0.25));
+    position: relative;
   }
-
+  .page__hero--overlay:after {
+    content: "";
+    position: absolute; inset: 0;
+    background-image: linear-gradient(var(--line-soft) 1px, transparent 1px), linear-gradient(90deg, var(--line-soft) 1px, transparent 1px);
+    background-size: 40px 40px;
+    opacity: 0.04;
+    pointer-events: none;
+  }
+  .page__hero--overlay .page__title { font-family: var(--font-display); }
   .page__hero--overlay .page__title,
   .page__hero--overlay .page__lead,
-  .page__hero--overlay .page__meta { color: #fff; }
-
+  .page__hero--overlay .page__meta { color: #fff; position: relative; z-index: 1; }
   .page__hero-caption { font-size: 0.85em; color: rgba(255, 255, 255, 0.6); }
 
   /* ---- Feature rows (homepage) -------------------------------------- */
   .feature__wrapper { border-bottom: 0; }
-
   .feature__item .archive__item-body { padding: 0.5em; }
-
-  .archive__item-title {
-    font-weight: 600;
-    letter-spacing: -0.01em;
-    margin-top: 0.4em;
-    margin-bottom: 0.4em;
-  }
-
+  .archive__item-title { font-family: var(--font-display); font-weight: 600; letter-spacing: -0.01em; margin-top: 0.4em; margin-bottom: 0.4em; }
   .archive__item-title a { color: var(--ink); }
-  .archive__item-title a:hover { color: var(--ink-soft); text-decoration: none; }
+  .archive__item-title a:hover { color: var(--accent); text-decoration: none; }
   .archive__item-excerpt { color: var(--ink-soft); line-height: 1.65; }
 
-  /* ---- Post / archive lists: hairline dividers, no cards ------------ */
+  /* ---- Post / archive lists ----------------------------------------- */
   .archive__item {
-    background: transparent;
-    border: 0;
-    border-radius: 0;
-    padding: 1.5em 0;
-    margin-bottom: 0;
-    box-shadow: none;
-    border-bottom: 1px solid var(--line);
-    transition: none;
+    background: transparent; border: 0; border-radius: 0; padding: 1.5em 0;
+    margin-bottom: 0; box-shadow: none; border-bottom: 1px solid var(--line); transition: none;
   }
-
   .archive__item:hover { box-shadow: none; transform: none; }
-
   .list__item { margin-bottom: 0; }
 
   /* ---- Meta, footer, share, taxonomy -------------------------------- */
   .page__meta { font-size: 0.85em; color: var(--ink-faint); }
   .page__meta .fa, .page__meta .fas, .page__meta .far { color: var(--ink-faint); }
-
   .page__share { margin-top: 2.5em; padding-top: 1.5em; border-top: 1px solid var(--line); }
   .page__share-title { font-weight: 600; color: var(--ink); }
-
-  .page__footer {
-    background: transparent;
-    margin-top: 4em;
-    border-top: 1px solid var(--line);
-    color: var(--ink-faint);
-  }
-
+  .page__footer { background: var(--bg-subtle); margin-top: 4em; border-top: 1px solid var(--line); color: var(--ink-faint); }
   .page__footer a { color: var(--ink-soft); }
+  .page__footer a:hover { color: var(--accent); }
   .page__footer-copyright { color: var(--ink-faint); font-size: 0.82em; }
   .page__footer-follow .social-icons a { color: var(--ink-soft); }
-
+  .page__footer-follow li { border-color: var(--line); }
   .taxonomy__title { color: var(--ink); font-weight: 600; }
   .taxonomy__count { color: var(--ink-faint); }
   .taxonomy__section .archive__subtitle { border-bottom: 1px solid var(--line); }
 
-  /* ---- Notices: flat, hairline-left --------------------------------- */
+  /* ---- Notices ------------------------------------------------------ */
   .notice, .notice--primary, .notice--info,
   .notice--success, .notice--warning, .notice--danger {
-    background: var(--bg-subtle);
-    border: 1px solid var(--line);
-    border-left: 2px solid var(--ink);
-    border-radius: 4px;
-    box-shadow: none;
+    background: var(--bg-subtle); border: 1px solid var(--line);
+    border-left: 2px solid var(--accent); border-radius: 4px; box-shadow: none; color: var(--ink-soft);
   }
 
   /* ---- Search ------------------------------------------------------- */
+  .search-content { background: var(--bg); }
   .search-content .search-input {
-    border: 0;
-    border-bottom: 1px solid var(--line);
-    border-radius: 0;
-    font-size: 1.6em;
-    font-weight: 300;
+    background: transparent; color: var(--ink);
+    border: 0; border-bottom: 1px solid var(--line); border-radius: 0; font-size: 1.6em; font-weight: 300;
   }
-
-  .search-content .search-input:focus {
-    border-bottom-color: var(--ink);
-    box-shadow: none;
-    outline: none;
-  }
+  .search-content .search-input:focus { border-bottom-color: var(--accent); box-shadow: none; outline: none; }
+  .initial-content, .search-content { background: var(--bg); }
 
   /* ---- Tables ------------------------------------------------------- */
   .page__content table { border: 1px solid var(--line); }
   .page__content th { background: var(--bg-subtle); color: var(--ink); border-bottom: 1px solid var(--line); }
-  .page__content td { border-bottom: 1px solid var(--line); }
+  .page__content td { border-bottom: 1px solid var(--line); color: var(--ink); }
+  .page__content tr:nth-child(2n) { background: var(--bg-subtle); }
 
   /* ---- Accessibility & selection ------------------------------------ */
-  a:focus, button:focus { outline: 2px solid var(--ink); outline-offset: 2px; }
-  ::selection { background: var(--ink); color: #fff; }
-  ::-moz-selection { background: var(--ink); color: #fff; }
+  a:focus, button:focus { outline: 2px solid var(--accent); outline-offset: 2px; }
+  ::selection { background: var(--accent); color: var(--accent-contrast); }
+  ::-moz-selection { background: var(--accent); color: var(--accent-contrast); }
 
   /* ---- Photo gallery (Flickr embeds) -------------------------------- */
-  .expo-gallery {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
-    gap: 0.75em;
-    margin: 1.75em 0 2.5em;
-  }
+  .expo-gallery { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 0.75em; margin: 1.75em 0 2.5em; }
+  .expo-gallery__item { position: relative; overflow: hidden; border: 1px solid var(--line); border-radius: 6px; background: var(--bg-subtle); aspect-ratio: 3 / 2; }
+  .expo-gallery__item img, .expo-gallery__item .flickr-embed-photo,
+  .expo-gallery__item > a, .expo-gallery__item .flickr-embed-container { width: 100% !important; height: 100% !important; display: block; }
+  .expo-gallery__item img, .expo-gallery__item .flickr-embed-photo { object-fit: cover; transition: transform 0.4s ease; }
+  .expo-gallery__item:hover img, .expo-gallery__item:hover .flickr-embed-photo { transform: scale(1.04); }
+  @media (max-width: 600px) { .expo-gallery { grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); } }
 
-  .expo-gallery__item {
-    position: relative;
-    overflow: hidden;
+  /* =====================================================================
+     Floating control dock (theme / accent / language)
+     ===================================================================== */
+  .xw-dock { position: fixed; right: 1.1rem; bottom: 1.1rem; z-index: 9999; font-family: var(--font-body); }
+  .xw-dock__toggle {
+    width: 46px; height: 46px; border-radius: 50%;
+    display: flex; align-items: center; justify-content: center;
+    background: var(--accent); color: var(--accent-contrast);
+    border: 0; cursor: pointer; box-shadow: var(--shadow-card);
+    font-size: 1.15rem; line-height: 1; transition: transform 0.2s ease;
+  }
+  .xw-dock__toggle:hover { transform: rotate(30deg) scale(1.05); }
+  .xw-dock__panel {
+    position: absolute; right: 0; bottom: 58px; width: 232px;
+    background: var(--bg-elev); border: 1px solid var(--line); border-radius: 12px;
+    box-shadow: var(--shadow-card); padding: 0.9rem; opacity: 0; visibility: hidden;
+    transform: translateY(8px) scale(0.98); transform-origin: bottom right;
+    transition: opacity 0.18s ease, transform 0.18s ease, visibility 0.18s;
+  }
+  .xw-dock.open .xw-dock__panel { opacity: 1; visibility: visible; transform: translateY(0) scale(1); }
+  .xw-dock__group { margin-bottom: 0.85rem; }
+  .xw-dock__group:last-child { margin-bottom: 0; }
+  .xw-dock__label {
+    font-family: var(--font-mono); font-size: 0.62rem; letter-spacing: 0.12em; text-transform: uppercase;
+    color: var(--ink-faint); margin-bottom: 0.45rem; display: block;
+  }
+  .xw-seg { display: flex; background: var(--bg-subtle); border: 1px solid var(--line); border-radius: 8px; padding: 3px; gap: 3px; }
+  .xw-seg button {
+    flex: 1; border: 0; background: transparent; color: var(--ink-soft); cursor: pointer;
+    font-family: var(--font-body); font-size: 0.8rem; font-weight: 500; padding: 0.4rem 0.2rem; border-radius: 6px;
+    display: flex; align-items: center; justify-content: center; gap: 0.35em; transition: all 0.15s ease;
+  }
+  .xw-seg button[aria-pressed="true"] { background: var(--accent); color: var(--accent-contrast); }
+  .xw-swatches { display: flex; gap: 0.5rem; flex-wrap: wrap; }
+  .xw-swatch {
+    width: 26px; height: 26px; border-radius: 50%; border: 2px solid transparent; cursor: pointer;
+    padding: 0; position: relative; transition: transform 0.15s ease;
+  }
+  .xw-swatch:hover { transform: scale(1.12); }
+  .xw-swatch[aria-pressed="true"] { border-color: var(--ink); }
+  .xw-swatch[aria-pressed="true"]:after {
+    content: ""; position: absolute; inset: -5px; border-radius: 50%; border: 1px solid var(--accent);
+  }
+  @media (max-width: 600px) { .xw-dock { right: 0.7rem; bottom: 0.7rem; } }
+
+  /* =====================================================================
+     CV page — custom "geek-professional" layout
+     ===================================================================== */
+  .is-cv .page__title, .is-cv .page__meta, .is-cv .page__lead { display: none; }
+  .is-cv .page__content { font-size: 1em; }
+  .is-cv .page__content > hr { display: none; }
+
+  .cv { max-width: 940px; margin: 0 auto; }
+
+  /* Terminal-style hero card */
+  .cv-hero {
+    background: var(--bg-elev); border: 1px solid var(--line); border-radius: 14px;
+    overflow: hidden; box-shadow: var(--shadow-card); margin: 0.5em 0 2.4em;
+  }
+  .cv-hero__bar {
+    display: flex; align-items: center; gap: 0.5rem; padding: 0.65rem 0.9rem;
+    background: var(--bg-subtle); border-bottom: 1px solid var(--line);
+  }
+  .cv-hero__dot { width: 11px; height: 11px; border-radius: 50%; display: inline-block; }
+  .cv-hero__dot--r { background: #ff5f57; } .cv-hero__dot--y { background: #febc2e; } .cv-hero__dot--g { background: #28c840; }
+  .cv-hero__file { font-family: var(--font-mono); font-size: 0.74rem; color: var(--ink-faint); margin-left: 0.5rem; }
+  .cv-hero__body { padding: 2rem 2rem 2.1rem; }
+  .cv-hero__prompt { font-family: var(--font-mono); font-size: 0.82rem; color: var(--ink-faint); margin-bottom: 1rem; }
+  .cv-hero__prompt .cv-cmd { color: var(--accent); }
+  .cv-hero__name {
+    font-family: var(--font-display); font-size: 2.6rem; font-weight: 700; letter-spacing: -0.03em;
+    line-height: 1.05; margin: 0 0 0.35rem; color: var(--ink);
+  }
+  .cv-hero__role { font-size: 1.12rem; color: var(--ink-soft); margin: 0 0 1.4rem; font-weight: 500; }
+  .cv-hero__role .cv-sep { color: var(--accent); margin: 0 0.45rem; }
+  .cv-hero__meta { display: flex; flex-wrap: wrap; gap: 0.5rem 1.4rem; margin-bottom: 1.6rem; }
+  .cv-hero__meta span { font-family: var(--font-mono); font-size: 0.8rem; color: var(--ink-soft); display: inline-flex; align-items: center; gap: 0.4em; }
+  .cv-hero__meta i { color: var(--accent); }
+  .cv-actions { display: flex; flex-wrap: wrap; gap: 0.6rem; }
+  .cv-btn {
+    display: inline-flex; align-items: center; gap: 0.5em; font-family: var(--font-body); font-weight: 500;
+    font-size: 0.86rem; padding: 0.55rem 1rem; border-radius: 8px; text-decoration: none; transition: all 0.15s ease;
     border: 1px solid var(--line);
-    border-radius: 6px;
-    background: var(--bg-subtle);
-    aspect-ratio: 3 / 2;
   }
+  .cv-btn--solid { background: var(--accent); color: var(--accent-contrast); border-color: var(--accent); }
+  .cv-btn--solid:hover { background: var(--accent-strong); border-color: var(--accent-strong); transform: translateY(-1px); }
+  .cv-btn--ghost { background: transparent; color: var(--ink); }
+  .cv-btn--ghost:hover { border-color: var(--accent); color: var(--accent); transform: translateY(-1px); }
 
-  /* Fill the tile whether the raw <img> or the embedr-generated markup is shown */
-  .expo-gallery__item img,
-  .expo-gallery__item .flickr-embed-photo,
-  .expo-gallery__item > a,
-  .expo-gallery__item .flickr-embed-container {
-    width: 100% !important;
-    height: 100% !important;
-    display: block;
+  /* Section headers */
+  .cv-section { margin: 2.6rem 0; }
+  .cv-section__head { display: flex; align-items: baseline; gap: 0.7rem; margin-bottom: 1.3rem; }
+  .cv-section__idx { font-family: var(--font-mono); font-size: 0.8rem; color: var(--accent); font-weight: 600; }
+  .cv-section__title { font-family: var(--font-display); font-size: 1.4rem; font-weight: 600; letter-spacing: -0.01em; color: var(--ink); margin: 0; }
+  .cv-section__rule { flex: 1; height: 1px; background: var(--line); align-self: center; }
+
+  .cv-lead { color: var(--ink-soft); line-height: 1.75; font-size: 1.02rem; max-width: 68ch; }
+
+  /* Skill clusters */
+  .cv-skills { display: grid; grid-template-columns: repeat(auto-fit, minmax(240px, 1fr)); gap: 1rem; }
+  .cv-skill {
+    background: var(--bg-elev); border: 1px solid var(--line); border-radius: 12px; padding: 1.15rem 1.2rem;
+    transition: border-color 0.15s ease, transform 0.15s ease;
   }
-
-  .expo-gallery__item img,
-  .expo-gallery__item .flickr-embed-photo {
-    object-fit: cover;
-    transition: transform 0.4s ease;
+  .cv-skill:hover { border-color: var(--accent); transform: translateY(-2px); }
+  .cv-skill__title {
+    font-family: var(--font-mono); font-size: 0.72rem; letter-spacing: 0.08em; text-transform: uppercase;
+    color: var(--ink-faint); margin-bottom: 0.85rem; display: flex; align-items: center; gap: 0.5em;
   }
+  .cv-skill__title i { color: var(--accent); }
+  .cv-tags { display: flex; flex-wrap: wrap; gap: 0.4rem; }
+  .cv-tag {
+    font-family: var(--font-mono); font-size: 0.76rem; color: var(--ink); background: var(--bg-subtle);
+    border: 1px solid var(--line); border-radius: 6px; padding: 0.25rem 0.55rem; transition: all 0.15s ease;
+  }
+  .cv-tag:hover { background: var(--accent-soft); border-color: var(--accent); color: var(--accent); }
 
-  .expo-gallery__item:hover img,
-  .expo-gallery__item:hover .flickr-embed-photo { transform: scale(1.04); }
+  /* Project cards */
+  .cv-projects { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem; }
+  .cv-proj {
+    display: flex; flex-direction: column; background: var(--bg-elev); border: 1px solid var(--line);
+    border-radius: 12px; padding: 1.25rem; text-decoration: none; transition: border-color 0.15s ease, transform 0.15s ease, box-shadow 0.15s ease;
+  }
+  .cv-proj:hover { border-color: var(--accent); transform: translateY(-3px); box-shadow: var(--shadow-card); }
+  .cv-proj__top { display: flex; align-items: center; justify-content: space-between; margin-bottom: 0.7rem; }
+  .cv-proj__name { font-family: var(--font-mono); font-size: 0.95rem; font-weight: 600; color: var(--ink); }
+  .cv-proj__name i { color: var(--accent); margin-right: 0.4em; }
+  .cv-proj__arrow { color: var(--ink-faint); transition: transform 0.15s ease, color 0.15s ease; }
+  .cv-proj:hover .cv-proj__arrow { color: var(--accent); transform: translate(2px, -2px); }
+  .cv-proj__desc { color: var(--ink-soft); font-size: 0.9rem; line-height: 1.6; margin-bottom: 0.9rem; flex: 1; }
+  .cv-proj__stack { display: flex; flex-wrap: wrap; gap: 0.35rem; }
+  .cv-proj__lang { font-family: var(--font-mono); font-size: 0.68rem; color: var(--ink-faint); background: var(--bg-subtle); border: 1px solid var(--line); border-radius: 4px; padding: 0.12rem 0.4rem; }
+
+  /* Focus / expertise list */
+  .cv-focus { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 0.6rem 1.6rem; }
+  .cv-focus__item {
+    display: flex; gap: 0.7rem; align-items: flex-start; padding: 0.6rem 0;
+    border-bottom: 1px solid var(--line-soft); color: var(--ink-soft); line-height: 1.5;
+  }
+  .cv-focus__item i { color: var(--accent); margin-top: 0.2rem; }
+  .cv-focus__item b { color: var(--ink); font-weight: 600; }
+
+  /* Owner note */
+  .cv-note {
+    background: var(--bg-subtle); border: 1px dashed var(--line); border-radius: 10px; padding: 1rem 1.2rem;
+    font-family: var(--font-mono); font-size: 0.8rem; color: var(--ink-faint); line-height: 1.6;
+  }
+  .cv-note b { color: var(--ink-soft); }
+
+  /* Contact */
+  .cv-contact { display: flex; flex-wrap: wrap; gap: 0.7rem; }
+  .cv-contact a {
+    display: inline-flex; align-items: center; gap: 0.55em; font-family: var(--font-mono); font-size: 0.85rem;
+    color: var(--ink); text-decoration: none; background: var(--bg-elev); border: 1px solid var(--line);
+    border-radius: 8px; padding: 0.6rem 1rem; transition: all 0.15s ease;
+  }
+  .cv-contact a:hover { border-color: var(--accent); color: var(--accent); transform: translateY(-1px); }
+  .cv-contact a i { color: var(--accent); }
 
   @media (max-width: 600px) {
-    .expo-gallery { grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); }
+    .cv-hero__body { padding: 1.5rem 1.25rem; }
+    .cv-hero__name { font-size: 2rem; }
   }
 
   /* ---- Responsive --------------------------------------------------- */
@@ -392,3 +499,173 @@
     .masthead__inner-wrap { padding: 0.75em; }
   }
 </style>
+
+<script>
+  /* =====================================================================
+     Theme controller, accent picker, and English/Chinese i18n
+     ===================================================================== */
+  (function () {
+    var root = document.documentElement;
+    var STORE = { theme: 'xw-theme', accent: 'xw-accent', lang: 'xw-lang' };
+
+    function get(key, fallback) { try { return localStorage.getItem(key) || fallback; } catch (e) { return fallback; } }
+    function set(key, val) { try { localStorage.setItem(key, val); } catch (e) {} }
+
+    var state = {
+      theme:  get(STORE.theme, root.getAttribute('data-theme') || 'light'),
+      accent: get(STORE.accent, 'graphite'),
+      lang:   get(STORE.lang, 'en')
+    };
+
+    /* ---- i18n: nav labels + UI chrome -------------------------------- */
+    var NAV = {
+      'Home':     { en: 'Home',     zh: '首页' },
+      'Posts':    { en: 'Posts',    zh: '文章' },
+      'Projects': { en: 'Projects', zh: '项目' },
+      'Gallery':  { en: 'Gallery',  zh: '相册' },
+      'CV':       { en: 'CV',       zh: '简历' },
+      'About':    { en: 'About',    zh: '关于' }
+    };
+
+    function applyLang(lang) {
+      root.setAttribute('data-lang', lang);
+      document.documentElement.lang = (lang === 'zh') ? 'zh-CN' : 'en';
+
+      /* Navigation links */
+      var links = document.querySelectorAll('.greedy-nav .visible-links a, .greedy-nav .hidden-links a');
+      links.forEach(function (a) {
+        var key = a.getAttribute('data-nav-key');
+        if (!key) { key = a.textContent.trim(); a.setAttribute('data-nav-key', key); }
+        if (NAV[key]) a.textContent = NAV[key][lang];
+      });
+
+      /* Any element opted into translation via data-i18n-en / data-i18n-zh */
+      document.querySelectorAll('[data-i18n-en]').forEach(function (el) {
+        var val = el.getAttribute('data-i18n-' + lang);
+        if (val !== null && val !== undefined) el.textContent = val;
+      });
+    }
+
+    function applyTheme(t) { root.setAttribute('data-theme', t); }
+    function applyAccent(a) { root.setAttribute('data-accent', a); }
+
+    applyTheme(state.theme);
+    applyAccent(state.accent);
+
+    /* ---- Build the floating control dock ----------------------------- */
+    var ACCENTS = [
+      { id: 'graphite', color: '#5b5b5b' },
+      { id: 'blue',     color: '#2563eb' },
+      { id: 'emerald',  color: '#059669' },
+      { id: 'violet',   color: '#7c3aed' },
+      { id: 'amber',    color: '#d97706' },
+      { id: 'rose',     color: '#e11d48' }
+    ];
+
+    var UI = {
+      appearance: { en: 'Appearance', zh: '外观' },
+      light:      { en: 'Light',      zh: '浅色' },
+      dark:       { en: 'Dark',       zh: '深色' },
+      accent:     { en: 'Accent',     zh: '主题色' },
+      language:   { en: 'Language',   zh: '语言' }
+    };
+
+    function buildDock() {
+      var dock = document.createElement('div');
+      dock.className = 'xw-dock';
+      dock.innerHTML =
+        '<button class="xw-dock__toggle" aria-label="Site settings" aria-expanded="false">&#9881;</button>' +
+        '<div class="xw-dock__panel" role="dialog" aria-label="Site settings">' +
+          '<div class="xw-dock__group">' +
+            '<span class="xw-dock__label" data-ui="appearance"></span>' +
+            '<div class="xw-seg" data-role="theme">' +
+              '<button data-val="light" aria-pressed="false"><span>&#9728;</span><span data-ui="light"></span></button>' +
+              '<button data-val="dark" aria-pressed="false"><span>&#9789;</span><span data-ui="dark"></span></button>' +
+            '</div>' +
+          '</div>' +
+          '<div class="xw-dock__group">' +
+            '<span class="xw-dock__label" data-ui="accent"></span>' +
+            '<div class="xw-swatches" data-role="accent"></div>' +
+          '</div>' +
+          '<div class="xw-dock__group">' +
+            '<span class="xw-dock__label" data-ui="language"></span>' +
+            '<div class="xw-seg" data-role="lang">' +
+              '<button data-val="en" aria-pressed="false">EN</button>' +
+              '<button data-val="zh" aria-pressed="false">&#20013;&#25991;</button>' +
+            '</div>' +
+          '</div>' +
+        '</div>';
+      document.body.appendChild(dock);
+
+      var toggle = dock.querySelector('.xw-dock__toggle');
+      var panel = dock.querySelector('.xw-dock__panel');
+      toggle.addEventListener('click', function (e) {
+        e.stopPropagation();
+        var open = dock.classList.toggle('open');
+        toggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+      });
+      document.addEventListener('click', function (e) {
+        if (!dock.contains(e.target)) { dock.classList.remove('open'); toggle.setAttribute('aria-expanded', 'false'); }
+      });
+
+      /* Accent swatches */
+      var swWrap = dock.querySelector('[data-role="accent"]');
+      ACCENTS.forEach(function (a) {
+        var b = document.createElement('button');
+        b.className = 'xw-swatch';
+        b.style.background = a.color;
+        b.setAttribute('data-val', a.id);
+        b.setAttribute('aria-label', a.id);
+        b.setAttribute('aria-pressed', 'false');
+        swWrap.appendChild(b);
+      });
+
+      /* Sync pressed states */
+      function sync() {
+        dock.querySelectorAll('[data-role="theme"] button').forEach(function (b) {
+          b.setAttribute('aria-pressed', b.getAttribute('data-val') === state.theme ? 'true' : 'false');
+        });
+        dock.querySelectorAll('[data-role="lang"] button').forEach(function (b) {
+          b.setAttribute('aria-pressed', b.getAttribute('data-val') === state.lang ? 'true' : 'false');
+        });
+        dock.querySelectorAll('[data-role="accent"] button').forEach(function (b) {
+          b.setAttribute('aria-pressed', b.getAttribute('data-val') === state.accent ? 'true' : 'false');
+        });
+      }
+
+      function labelDock(lang) {
+        dock.querySelectorAll('[data-ui]').forEach(function (el) {
+          var k = el.getAttribute('data-ui');
+          if (UI[k]) el.textContent = UI[k][lang];
+        });
+        toggle.setAttribute('aria-label', UI.appearance[lang] === undefined ? 'Settings' : (lang === 'zh' ? '设置' : 'Settings'));
+      }
+
+      dock.querySelector('[data-role="theme"]').addEventListener('click', function (e) {
+        var b = e.target.closest('button'); if (!b) return;
+        state.theme = b.getAttribute('data-val'); set(STORE.theme, state.theme); applyTheme(state.theme); sync();
+      });
+      dock.querySelector('[data-role="lang"]').addEventListener('click', function (e) {
+        var b = e.target.closest('button'); if (!b) return;
+        state.lang = b.getAttribute('data-val'); set(STORE.lang, state.lang); applyLang(state.lang); labelDock(state.lang); sync();
+      });
+      swWrap.addEventListener('click', function (e) {
+        var b = e.target.closest('button'); if (!b) return;
+        state.accent = b.getAttribute('data-val'); set(STORE.accent, state.accent); applyAccent(state.accent); sync();
+      });
+
+      labelDock(state.lang);
+      sync();
+    }
+
+    /* ---- Boot -------------------------------------------------------- */
+    function boot() {
+      if (/^\/cv\/?$/.test(location.pathname)) document.body.classList.add('is-cv');
+      applyLang(state.lang);
+      buildDock();
+    }
+
+    if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', boot);
+    else boot();
+  })();
+</script>

--- a/_pages/cv.md
+++ b/_pages/cv.md
@@ -1,11 +1,11 @@
-﻿---
+---
 title: "Curriculum Vitae"
 permalink: /cv/
 layout: single
 author_profile: false
 classes: wide
 toc: false
-excerpt: "Image Algorithms R&D Â· Technical Project Leader"
+excerpt: "Image Algorithms R&D · Technical Project Leader"
 ---
 
 <div class="cv" markdown="0">
@@ -16,33 +16,25 @@ excerpt: "Image Algorithms R&D Â· Technical Project Leader"
       <span class="cv-hero__dot cv-hero__dot--r"></span>
       <span class="cv-hero__dot cv-hero__dot--y"></span>
       <span class="cv-hero__dot cv-hero__dot--g"></span>
-      <span class="cv-hero__file">xingchen_wang â€” curriculum_vitae</span>
+      <span class="cv-hero__file">xingchen_wang — curriculum_vitae</span>
     </div>
     <div class="cv-hero__body">
-      <div class="cv-hero__prompt">
-        <span class="cv-cmd">$</span>
-        <span data-i18n-en="whoami --profile" data-i18n-zh="whoami --profile">whoami --profile</span>
-      </div>
+      <div class="cv-hero__prompt"><span class="cv-cmd">$</span> whoami --profile</div>
       <h1 class="cv-hero__name">Xingchen Wang</h1>
       <p class="cv-hero__role">
-        <span data-i18n-en="Image Algorithms R&amp;D" data-i18n-zh="å›¾åƒç®—æ³•ç ”å‘">Image Algorithms R&amp;D</span>
-        <span class="cv-sep">/</span>
-        <span data-i18n-en="Technical Project Leader" data-i18n-zh="æŠ€æœ¯é¡¹ç›®è´Ÿè´£äºº">Technical Project Leader</span>
+        Image Algorithms R&amp;D <span class="cv-sep">/</span> Technical Project Leader
       </p>
       <div class="cv-hero__meta">
-        <span><i class="fas fa-microchip"></i><span data-i18n-en="Computer Vision" data-i18n-zh="è®¡ç®—æœºè§†è§‰">Computer Vision</span></span>
+        <span><i class="fas fa-microchip"></i>Computer Vision</span>
         <span><i class="fas fa-code"></i>C++ / Python</span>
-        <span><i class="fas fa-globe"></i><span data-i18n-en="Global" data-i18n-zh="å…¨çƒ">Global</span></span>
+        <span><i class="fas fa-globe"></i>Global</span>
       </div>
       <div class="cv-actions">
         <a class="cv-btn cv-btn--solid" href="https://github.com/Xingchen1224" target="_blank" rel="noopener">
-          <i class="fab fa-github"></i><span data-i18n-en="GitHub" data-i18n-zh="GitHub">GitHub</span>
+          <i class="fab fa-github"></i>GitHub
         </a>
         <a class="cv-btn cv-btn--ghost" href="https://www.linkedin.com/in/xingchen-wang" target="_blank" rel="noopener">
-          <i class="fab fa-linkedin"></i><span data-i18n-en="LinkedIn" data-i18n-zh="é¢†è‹±">LinkedIn</span>
-        </a>
-        <a class="cv-btn cv-btn--ghost" href="/projects/">
-          <i class="fas fa-folder-open"></i><span data-i18n-en="Projects" data-i18n-zh="é¡¹ç›®">Projects</span>
+          <i class="fab fa-linkedin"></i>LinkedIn
         </a>
       </div>
     </div>
@@ -52,27 +44,24 @@ excerpt: "Image Algorithms R&D Â· Technical Project Leader"
   <section class="cv-section">
     <div class="cv-section__head">
       <span class="cv-section__idx">01</span>
-      <h2 class="cv-section__title" data-i18n-en="Summary" data-i18n-zh="æ¦‚è¦">Summary</h2>
+      <h2 class="cv-section__title">Summary</h2>
       <span class="cv-section__rule"></span>
     </div>
-    <p class="cv-lead"
-       data-i18n-en="Image Algorithms R&amp;D engineer and Technical Project Leader working across image processing, computer vision, and computational imaging. I focus on taking algorithms from prototype to production-quality software, and on leading the engineering work that turns research into reliable systems."
-       data-i18n-zh="å›¾åƒç®—æ³•ç ”å‘å·¥ç¨‹å¸ˆä¸ŽæŠ€æœ¯é¡¹ç›®è´Ÿè´£äººï¼Œå·¥ä½œæ–¹å‘æ¶µç›–å›¾åƒå¤„ç†ã€è®¡ç®—æœºè§†è§‰ä¸Žè®¡ç®—æ‘„å½±ã€‚æˆ‘ä¸“æ³¨äºŽå°†ç®—æ³•ä»ŽåŽŸåž‹æŽ¨è¿›åˆ°å¯ç”¨äºŽç”Ÿäº§çš„é«˜è´¨é‡è½¯ä»¶ï¼Œå¹¶å¸¦é¢†å·¥ç¨‹å›¢é˜ŸæŠŠç ”ç©¶æˆæžœè½¬åŒ–ä¸ºå¯é çš„ç³»ç»Ÿã€‚">Image
-      Algorithms R&amp;D engineer and Technical Project Leader working across image processing, computer vision,
-      and computational imaging. I focus on taking algorithms from prototype to production-quality software, and
-      on leading the engineering work that turns research into reliable systems.</p>
+    <p class="cv-lead">Image Algorithms R&amp;D engineer and Technical Project Leader working across image
+      processing, computer vision, and computational imaging. I focus on taking algorithms from prototype to
+      production-quality software, and on leading the engineering work that turns research into reliable systems.</p>
   </section>
 
   <!-- ============================ SKILLS ============================ -->
   <section class="cv-section">
     <div class="cv-section__head">
       <span class="cv-section__idx">02</span>
-      <h2 class="cv-section__title" data-i18n-en="Technical Skills" data-i18n-zh="æŠ€æœ¯èƒ½åŠ›">Technical Skills</h2>
+      <h2 class="cv-section__title">Technical Skills</h2>
       <span class="cv-section__rule"></span>
     </div>
     <div class="cv-skills">
       <div class="cv-skill">
-        <div class="cv-skill__title"><i class="fas fa-eye"></i><span data-i18n-en="Image &amp; Vision" data-i18n-zh="å›¾åƒä¸Žè§†è§‰">Image &amp; Vision</span></div>
+        <div class="cv-skill__title"><i class="fas fa-eye"></i>Image &amp; Vision</div>
         <div class="cv-tags">
           <span class="cv-tag">Image Algorithms</span>
           <span class="cv-tag">Image Processing</span>
@@ -82,7 +71,7 @@ excerpt: "Image Algorithms R&D Â· Technical Project Leader"
         </div>
       </div>
       <div class="cv-skill">
-        <div class="cv-skill__title"><i class="fas fa-terminal"></i><span data-i18n-en="Languages &amp; Tooling" data-i18n-zh="è¯­è¨€ä¸Žå·¥å…·">Languages &amp; Tooling</span></div>
+        <div class="cv-skill__title"><i class="fas fa-terminal"></i>Languages &amp; Tooling</div>
         <div class="cv-tags">
           <span class="cv-tag">C++</span>
           <span class="cv-tag">Python</span>
@@ -92,7 +81,7 @@ excerpt: "Image Algorithms R&D Â· Technical Project Leader"
         </div>
       </div>
       <div class="cv-skill">
-        <div class="cv-skill__title"><i class="fas fa-cubes"></i><span data-i18n-en="Frameworks &amp; Domains" data-i18n-zh="æ¡†æž¶ä¸Žé¢†åŸŸ">Frameworks &amp; Domains</span></div>
+        <div class="cv-skill__title"><i class="fas fa-cubes"></i>Frameworks &amp; Domains</div>
         <div class="cv-tags">
           <span class="cv-tag">JUCE</span>
           <span class="cv-tag">Cross-platform C++</span>
@@ -100,66 +89,31 @@ excerpt: "Image Algorithms R&D Â· Technical Project Leader"
         </div>
       </div>
       <div class="cv-skill">
-        <div class="cv-skill__title"><i class="fas fa-sitemap"></i><span data-i18n-en="Leadership" data-i18n-zh="å›¢é˜Ÿä¸Žé¢†å¯¼">Leadership</span></div>
+        <div class="cv-skill__title"><i class="fas fa-sitemap"></i>Leadership</div>
         <div class="cv-tags">
-          <span class="cv-tag" data-i18n-en="Project Leadership" data-i18n-zh="é¡¹ç›®é¢†å¯¼">Project Leadership</span>
-          <span class="cv-tag" data-i18n-en="R&amp;D Planning" data-i18n-zh="ç ”å‘è§„åˆ’">R&amp;D Planning</span>
-          <span class="cv-tag" data-i18n-en="Code Review" data-i18n-zh="ä»£ç è¯„å®¡">Code Review</span>
-          <span class="cv-tag" data-i18n-en="System Design" data-i18n-zh="ç³»ç»Ÿè®¾è®¡">System Design</span>
+          <span class="cv-tag">Project Leadership</span>
+          <span class="cv-tag">R&amp;D Planning</span>
+          <span class="cv-tag">Code Review</span>
+          <span class="cv-tag">System Design</span>
         </div>
       </div>
-    </div>
-  </section>
-
-  <!-- ============================ PROJECTS ============================ -->
-  <section class="cv-section">
-    <div class="cv-section__head">
-      <span class="cv-section__idx">03</span>
-      <h2 class="cv-section__title" data-i18n-en="Selected Open-Source Projects" data-i18n-zh="ç²¾é€‰å¼€æºé¡¹ç›®">Selected Open-Source Projects</h2>
-      <span class="cv-section__rule"></span>
-    </div>
-    <div class="cv-projects">
-      <a class="cv-proj" href="https://github.com/Xingchen1224/opencv_build_as_you_go" target="_blank" rel="noopener">
-        <div class="cv-proj__top">
-          <span class="cv-proj__name"><i class="fas fa-code-branch"></i>opencv_build_as_you_go</span>
-          <span class="cv-proj__arrow"><i class="fas fa-external-link-alt"></i></span>
-        </div>
-        <p class="cv-proj__desc" data-i18n-en="Scripts to build OpenCV as simply as possible." data-i18n-zh="ä»¥å°½å¯èƒ½ç®€å•çš„æ–¹å¼æž„å»º OpenCV çš„è„šæœ¬å·¥å…·ã€‚">Scripts to build OpenCV as simply as possible.</p>
-        <div class="cv-proj__stack"><span class="cv-proj__lang">Shell</span><span class="cv-proj__lang">CMake</span></div>
-      </a>
-      <a class="cv-proj" href="https://github.com/Xingchen1224/JUCE-Extra-Components" target="_blank" rel="noopener">
-        <div class="cv-proj__top">
-          <span class="cv-proj__name"><i class="fas fa-code-branch"></i>JUCE-Extra-Components</span>
-          <span class="cv-proj__arrow"><i class="fas fa-external-link-alt"></i></span>
-        </div>
-        <p class="cv-proj__desc" data-i18n-en="Additional reusable components built on the JUCE framework." data-i18n-zh="åŸºäºŽ JUCE æ¡†æž¶æž„å»ºçš„å¯å¤ç”¨ç»„ä»¶é›†åˆã€‚">Additional reusable components built on the JUCE framework.</p>
-        <div class="cv-proj__stack"><span class="cv-proj__lang">C++</span><span class="cv-proj__lang">JUCE</span></div>
-      </a>
-      <a class="cv-proj" href="https://github.com/Xingchen1224/project_template_cpp" target="_blank" rel="noopener">
-        <div class="cv-proj__top">
-          <span class="cv-proj__name"><i class="fas fa-code-branch"></i>project_template_cpp</span>
-          <span class="cv-proj__arrow"><i class="fas fa-external-link-alt"></i></span>
-        </div>
-        <p class="cv-proj__desc" data-i18n-en="A CMake project template for bootstrapping C++ projects." data-i18n-zh="ç”¨äºŽå¿«é€Ÿæ­å»º C++ é¡¹ç›®çš„ CMake å·¥ç¨‹æ¨¡æ¿ã€‚">A CMake project template for bootstrapping C++ projects.</p>
-        <div class="cv-proj__stack"><span class="cv-proj__lang">C++</span><span class="cv-proj__lang">CMake</span></div>
-      </a>
     </div>
   </section>
 
   <!-- ============================ FOCUS ============================ -->
   <section class="cv-section">
     <div class="cv-section__head">
-      <span class="cv-section__idx">04</span>
-      <h2 class="cv-section__title" data-i18n-en="Areas of Focus" data-i18n-zh="ä¸“æ³¨é¢†åŸŸ">Areas of Focus</h2>
+      <span class="cv-section__idx">03</span>
+      <h2 class="cv-section__title">Areas of Focus</h2>
       <span class="cv-section__rule"></span>
     </div>
     <div class="cv-focus">
-      <div class="cv-focus__item"><i class="fas fa-chevron-right"></i><span><b data-i18n-en="Computational imaging" data-i18n-zh="è®¡ç®—æ‘„å½±">Computational imaging</b> <span data-i18n-en="&amp; image-quality algorithms" data-i18n-zh="ä¸Žå›¾åƒè´¨é‡ç®—æ³•">&amp; image-quality algorithms</span></span></div>
-      <div class="cv-focus__item"><i class="fas fa-chevron-right"></i><span><b data-i18n-en="Computer vision" data-i18n-zh="è®¡ç®—æœºè§†è§‰">Computer vision</b> <span data-i18n-en="&amp; visual perception systems" data-i18n-zh="ä¸Žè§†è§‰æ„ŸçŸ¥ç³»ç»Ÿ">&amp; visual perception systems</span></span></div>
-      <div class="cv-focus__item"><i class="fas fa-chevron-right"></i><span><b data-i18n-en="Image pipeline architecture" data-i18n-zh="å›¾åƒæµæ°´çº¿æž¶æž„">Image pipeline architecture</b> <span data-i18n-en="(RAW, ISP, post-processing)" data-i18n-zh="ï¼ˆRAWã€ISPã€åŽå¤„ç†ï¼‰">(RAW, ISP, post-processing)</span></span></div>
-      <div class="cv-focus__item"><i class="fas fa-chevron-right"></i><span><b data-i18n-en="Algorithm-to-production" data-i18n-zh="ä»Žç®—æ³•åˆ°ç”Ÿäº§">Algorithm-to-production</b> <span data-i18n-en="engineering &amp; tooling" data-i18n-zh="å·¥ç¨‹åŒ–ä¸Žå·¥å…·é“¾">engineering &amp; tooling</span></span></div>
-      <div class="cv-focus__item"><i class="fas fa-chevron-right"></i><span><b data-i18n-en="Technical leadership" data-i18n-zh="æŠ€æœ¯é¢†å¯¼">Technical leadership</b> <span data-i18n-en="&amp; cross-functional teams" data-i18n-zh="ä¸Žè·¨èŒèƒ½å›¢é˜Ÿåä½œ">&amp; cross-functional teams</span></span></div>
-      <div class="cv-focus__item"><i class="fas fa-chevron-right"></i><span><b data-i18n-en="System design" data-i18n-zh="ç³»ç»Ÿè®¾è®¡">System design</b> <span data-i18n-en="&amp; engineering quality" data-i18n-zh="ä¸Žå·¥ç¨‹è´¨é‡å®žè·µ">&amp; engineering quality</span></span></div>
+      <div class="cv-focus__item"><i class="fas fa-chevron-right"></i><span><b>Computational imaging</b> &amp; image-quality algorithms</span></div>
+      <div class="cv-focus__item"><i class="fas fa-chevron-right"></i><span><b>Computer vision</b> &amp; visual perception systems</span></div>
+      <div class="cv-focus__item"><i class="fas fa-chevron-right"></i><span><b>Image pipeline architecture</b> (RAW, ISP, post-processing)</span></div>
+      <div class="cv-focus__item"><i class="fas fa-chevron-right"></i><span><b>Algorithm-to-production</b> engineering &amp; tooling</span></div>
+      <div class="cv-focus__item"><i class="fas fa-chevron-right"></i><span><b>Technical leadership</b> &amp; cross-functional teams</span></div>
+      <div class="cv-focus__item"><i class="fas fa-chevron-right"></i><span><b>System design</b> &amp; engineering quality</span></div>
     </div>
   </section>
 
@@ -178,8 +132,8 @@ excerpt: "Image Algorithms R&D Â· Technical Project Leader"
   <!-- ============================ CONTACT ============================ -->
   <section class="cv-section">
     <div class="cv-section__head">
-      <span class="cv-section__idx">05</span>
-      <h2 class="cv-section__title" data-i18n-en="Contact" data-i18n-zh="è”ç³»æ–¹å¼">Contact</h2>
+      <span class="cv-section__idx">04</span>
+      <h2 class="cv-section__title">Contact</h2>
       <span class="cv-section__rule"></span>
     </div>
     <div class="cv-contact">

--- a/_pages/cv.md
+++ b/_pages/cv.md
@@ -1,89 +1,191 @@
----
+﻿---
 title: "Curriculum Vitae"
 permalink: /cv/
 layout: single
-author_profile: true
+author_profile: false
 classes: wide
-excerpt: "Image Algorithms R&D · Technical Project Leader"
-toc: true
-toc_label: "CV Contents"
-toc_icon: "file-alt"
+toc: false
+excerpt: "Image Algorithms R&D Â· Technical Project Leader"
 ---
 
-## Summary
+<div class="cv" markdown="0">
 
-Image Algorithms R&D engineer and Technical Project Leader working across image
-processing, computer vision, and computational imaging. I focus on taking algorithms
-from prototype to production-quality software, and on leading the engineering work that
-turns research into reliable systems.
+  <!-- ============================ HERO ============================ -->
+  <section class="cv-hero">
+    <div class="cv-hero__bar">
+      <span class="cv-hero__dot cv-hero__dot--r"></span>
+      <span class="cv-hero__dot cv-hero__dot--y"></span>
+      <span class="cv-hero__dot cv-hero__dot--g"></span>
+      <span class="cv-hero__file">xingchen_wang â€” curriculum_vitae</span>
+    </div>
+    <div class="cv-hero__body">
+      <div class="cv-hero__prompt">
+        <span class="cv-cmd">$</span>
+        <span data-i18n-en="whoami --profile" data-i18n-zh="whoami --profile">whoami --profile</span>
+      </div>
+      <h1 class="cv-hero__name">Xingchen Wang</h1>
+      <p class="cv-hero__role">
+        <span data-i18n-en="Image Algorithms R&amp;D" data-i18n-zh="å›¾åƒç®—æ³•ç ”å‘">Image Algorithms R&amp;D</span>
+        <span class="cv-sep">/</span>
+        <span data-i18n-en="Technical Project Leader" data-i18n-zh="æŠ€æœ¯é¡¹ç›®è´Ÿè´£äºº">Technical Project Leader</span>
+      </p>
+      <div class="cv-hero__meta">
+        <span><i class="fas fa-microchip"></i><span data-i18n-en="Computer Vision" data-i18n-zh="è®¡ç®—æœºè§†è§‰">Computer Vision</span></span>
+        <span><i class="fas fa-code"></i>C++ / Python</span>
+        <span><i class="fas fa-globe"></i><span data-i18n-en="Global" data-i18n-zh="å…¨çƒ">Global</span></span>
+      </div>
+      <div class="cv-actions">
+        <a class="cv-btn cv-btn--solid" href="https://github.com/Xingchen1224" target="_blank" rel="noopener">
+          <i class="fab fa-github"></i><span data-i18n-en="GitHub" data-i18n-zh="GitHub">GitHub</span>
+        </a>
+        <a class="cv-btn cv-btn--ghost" href="https://www.linkedin.com/in/xingchen-wang" target="_blank" rel="noopener">
+          <i class="fab fa-linkedin"></i><span data-i18n-en="LinkedIn" data-i18n-zh="é¢†è‹±">LinkedIn</span>
+        </a>
+        <a class="cv-btn cv-btn--ghost" href="/projects/">
+          <i class="fas fa-folder-open"></i><span data-i18n-en="Projects" data-i18n-zh="é¡¹ç›®">Projects</span>
+        </a>
+      </div>
+    </div>
+  </section>
 
----
+  <!-- ============================ SUMMARY ============================ -->
+  <section class="cv-section">
+    <div class="cv-section__head">
+      <span class="cv-section__idx">01</span>
+      <h2 class="cv-section__title" data-i18n-en="Summary" data-i18n-zh="æ¦‚è¦">Summary</h2>
+      <span class="cv-section__rule"></span>
+    </div>
+    <p class="cv-lead"
+       data-i18n-en="Image Algorithms R&amp;D engineer and Technical Project Leader working across image processing, computer vision, and computational imaging. I focus on taking algorithms from prototype to production-quality software, and on leading the engineering work that turns research into reliable systems."
+       data-i18n-zh="å›¾åƒç®—æ³•ç ”å‘å·¥ç¨‹å¸ˆä¸ŽæŠ€æœ¯é¡¹ç›®è´Ÿè´£äººï¼Œå·¥ä½œæ–¹å‘æ¶µç›–å›¾åƒå¤„ç†ã€è®¡ç®—æœºè§†è§‰ä¸Žè®¡ç®—æ‘„å½±ã€‚æˆ‘ä¸“æ³¨äºŽå°†ç®—æ³•ä»ŽåŽŸåž‹æŽ¨è¿›åˆ°å¯ç”¨äºŽç”Ÿäº§çš„é«˜è´¨é‡è½¯ä»¶ï¼Œå¹¶å¸¦é¢†å·¥ç¨‹å›¢é˜ŸæŠŠç ”ç©¶æˆæžœè½¬åŒ–ä¸ºå¯é çš„ç³»ç»Ÿã€‚">Image
+      Algorithms R&amp;D engineer and Technical Project Leader working across image processing, computer vision,
+      and computational imaging. I focus on taking algorithms from prototype to production-quality software, and
+      on leading the engineering work that turns research into reliable systems.</p>
+  </section>
 
-## Technical Skills
+  <!-- ============================ SKILLS ============================ -->
+  <section class="cv-section">
+    <div class="cv-section__head">
+      <span class="cv-section__idx">02</span>
+      <h2 class="cv-section__title" data-i18n-en="Technical Skills" data-i18n-zh="æŠ€æœ¯èƒ½åŠ›">Technical Skills</h2>
+      <span class="cv-section__rule"></span>
+    </div>
+    <div class="cv-skills">
+      <div class="cv-skill">
+        <div class="cv-skill__title"><i class="fas fa-eye"></i><span data-i18n-en="Image &amp; Vision" data-i18n-zh="å›¾åƒä¸Žè§†è§‰">Image &amp; Vision</span></div>
+        <div class="cv-tags">
+          <span class="cv-tag">Image Algorithms</span>
+          <span class="cv-tag">Image Processing</span>
+          <span class="cv-tag">Computer Vision</span>
+          <span class="cv-tag">Computational Imaging</span>
+          <span class="cv-tag">OpenCV</span>
+        </div>
+      </div>
+      <div class="cv-skill">
+        <div class="cv-skill__title"><i class="fas fa-terminal"></i><span data-i18n-en="Languages &amp; Tooling" data-i18n-zh="è¯­è¨€ä¸Žå·¥å…·">Languages &amp; Tooling</span></div>
+        <div class="cv-tags">
+          <span class="cv-tag">C++</span>
+          <span class="cv-tag">Python</span>
+          <span class="cv-tag">Shell</span>
+          <span class="cv-tag">CMake</span>
+          <span class="cv-tag">Git</span>
+        </div>
+      </div>
+      <div class="cv-skill">
+        <div class="cv-skill__title"><i class="fas fa-cubes"></i><span data-i18n-en="Frameworks &amp; Domains" data-i18n-zh="æ¡†æž¶ä¸Žé¢†åŸŸ">Frameworks &amp; Domains</span></div>
+        <div class="cv-tags">
+          <span class="cv-tag">JUCE</span>
+          <span class="cv-tag">Cross-platform C++</span>
+          <span class="cv-tag">Build Systems</span>
+        </div>
+      </div>
+      <div class="cv-skill">
+        <div class="cv-skill__title"><i class="fas fa-sitemap"></i><span data-i18n-en="Leadership" data-i18n-zh="å›¢é˜Ÿä¸Žé¢†å¯¼">Leadership</span></div>
+        <div class="cv-tags">
+          <span class="cv-tag" data-i18n-en="Project Leadership" data-i18n-zh="é¡¹ç›®é¢†å¯¼">Project Leadership</span>
+          <span class="cv-tag" data-i18n-en="R&amp;D Planning" data-i18n-zh="ç ”å‘è§„åˆ’">R&amp;D Planning</span>
+          <span class="cv-tag" data-i18n-en="Code Review" data-i18n-zh="ä»£ç è¯„å®¡">Code Review</span>
+          <span class="cv-tag" data-i18n-en="System Design" data-i18n-zh="ç³»ç»Ÿè®¾è®¡">System Design</span>
+        </div>
+      </div>
+    </div>
+  </section>
 
-### Image & Vision
-`Image Algorithms`  `Image Processing`  `Computer Vision`  `Computational Imaging`
-`OpenCV`
+  <!-- ============================ PROJECTS ============================ -->
+  <section class="cv-section">
+    <div class="cv-section__head">
+      <span class="cv-section__idx">03</span>
+      <h2 class="cv-section__title" data-i18n-en="Selected Open-Source Projects" data-i18n-zh="ç²¾é€‰å¼€æºé¡¹ç›®">Selected Open-Source Projects</h2>
+      <span class="cv-section__rule"></span>
+    </div>
+    <div class="cv-projects">
+      <a class="cv-proj" href="https://github.com/Xingchen1224/opencv_build_as_you_go" target="_blank" rel="noopener">
+        <div class="cv-proj__top">
+          <span class="cv-proj__name"><i class="fas fa-code-branch"></i>opencv_build_as_you_go</span>
+          <span class="cv-proj__arrow"><i class="fas fa-external-link-alt"></i></span>
+        </div>
+        <p class="cv-proj__desc" data-i18n-en="Scripts to build OpenCV as simply as possible." data-i18n-zh="ä»¥å°½å¯èƒ½ç®€å•çš„æ–¹å¼æž„å»º OpenCV çš„è„šæœ¬å·¥å…·ã€‚">Scripts to build OpenCV as simply as possible.</p>
+        <div class="cv-proj__stack"><span class="cv-proj__lang">Shell</span><span class="cv-proj__lang">CMake</span></div>
+      </a>
+      <a class="cv-proj" href="https://github.com/Xingchen1224/JUCE-Extra-Components" target="_blank" rel="noopener">
+        <div class="cv-proj__top">
+          <span class="cv-proj__name"><i class="fas fa-code-branch"></i>JUCE-Extra-Components</span>
+          <span class="cv-proj__arrow"><i class="fas fa-external-link-alt"></i></span>
+        </div>
+        <p class="cv-proj__desc" data-i18n-en="Additional reusable components built on the JUCE framework." data-i18n-zh="åŸºäºŽ JUCE æ¡†æž¶æž„å»ºçš„å¯å¤ç”¨ç»„ä»¶é›†åˆã€‚">Additional reusable components built on the JUCE framework.</p>
+        <div class="cv-proj__stack"><span class="cv-proj__lang">C++</span><span class="cv-proj__lang">JUCE</span></div>
+      </a>
+      <a class="cv-proj" href="https://github.com/Xingchen1224/project_template_cpp" target="_blank" rel="noopener">
+        <div class="cv-proj__top">
+          <span class="cv-proj__name"><i class="fas fa-code-branch"></i>project_template_cpp</span>
+          <span class="cv-proj__arrow"><i class="fas fa-external-link-alt"></i></span>
+        </div>
+        <p class="cv-proj__desc" data-i18n-en="A CMake project template for bootstrapping C++ projects." data-i18n-zh="ç”¨äºŽå¿«é€Ÿæ­å»º C++ é¡¹ç›®çš„ CMake å·¥ç¨‹æ¨¡æ¿ã€‚">A CMake project template for bootstrapping C++ projects.</p>
+        <div class="cv-proj__stack"><span class="cv-proj__lang">C++</span><span class="cv-proj__lang">CMake</span></div>
+      </a>
+    </div>
+  </section>
 
-### Languages & Tooling
-`C++`  `Python`  `Shell`  `CMake`  `Git`
+  <!-- ============================ FOCUS ============================ -->
+  <section class="cv-section">
+    <div class="cv-section__head">
+      <span class="cv-section__idx">04</span>
+      <h2 class="cv-section__title" data-i18n-en="Areas of Focus" data-i18n-zh="ä¸“æ³¨é¢†åŸŸ">Areas of Focus</h2>
+      <span class="cv-section__rule"></span>
+    </div>
+    <div class="cv-focus">
+      <div class="cv-focus__item"><i class="fas fa-chevron-right"></i><span><b data-i18n-en="Computational imaging" data-i18n-zh="è®¡ç®—æ‘„å½±">Computational imaging</b> <span data-i18n-en="&amp; image-quality algorithms" data-i18n-zh="ä¸Žå›¾åƒè´¨é‡ç®—æ³•">&amp; image-quality algorithms</span></span></div>
+      <div class="cv-focus__item"><i class="fas fa-chevron-right"></i><span><b data-i18n-en="Computer vision" data-i18n-zh="è®¡ç®—æœºè§†è§‰">Computer vision</b> <span data-i18n-en="&amp; visual perception systems" data-i18n-zh="ä¸Žè§†è§‰æ„ŸçŸ¥ç³»ç»Ÿ">&amp; visual perception systems</span></span></div>
+      <div class="cv-focus__item"><i class="fas fa-chevron-right"></i><span><b data-i18n-en="Image pipeline architecture" data-i18n-zh="å›¾åƒæµæ°´çº¿æž¶æž„">Image pipeline architecture</b> <span data-i18n-en="(RAW, ISP, post-processing)" data-i18n-zh="ï¼ˆRAWã€ISPã€åŽå¤„ç†ï¼‰">(RAW, ISP, post-processing)</span></span></div>
+      <div class="cv-focus__item"><i class="fas fa-chevron-right"></i><span><b data-i18n-en="Algorithm-to-production" data-i18n-zh="ä»Žç®—æ³•åˆ°ç”Ÿäº§">Algorithm-to-production</b> <span data-i18n-en="engineering &amp; tooling" data-i18n-zh="å·¥ç¨‹åŒ–ä¸Žå·¥å…·é“¾">engineering &amp; tooling</span></span></div>
+      <div class="cv-focus__item"><i class="fas fa-chevron-right"></i><span><b data-i18n-en="Technical leadership" data-i18n-zh="æŠ€æœ¯é¢†å¯¼">Technical leadership</b> <span data-i18n-en="&amp; cross-functional teams" data-i18n-zh="ä¸Žè·¨èŒèƒ½å›¢é˜Ÿåä½œ">&amp; cross-functional teams</span></span></div>
+      <div class="cv-focus__item"><i class="fas fa-chevron-right"></i><span><b data-i18n-en="System design" data-i18n-zh="ç³»ç»Ÿè®¾è®¡">System design</b> <span data-i18n-en="&amp; engineering quality" data-i18n-zh="ä¸Žå·¥ç¨‹è´¨é‡å®žè·µ">&amp; engineering quality</span></span></div>
+    </div>
+  </section>
 
-### Frameworks & Domains
-`JUCE`  `Cross-platform C++`  `Build systems & tooling`
+  <!--
+    ============================================================================
+    TO THE SITE OWNER
+    ----------------------------------------------------------------------------
+    Professional Experience, Education, Publications and Languages are intentionally
+    omitted rather than invented, because no verifiable public source was available
+    (LinkedIn is blocked in the build environment). Add your real details below and
+    they will render inside a styled timeline. Everything above uses only verifiable,
+    public information.
+    ============================================================================
+  -->
 
-### Leadership
-`Technical Project Leadership`  `R&D Planning`  `Code Review`  `System Design`
+  <!-- ============================ CONTACT ============================ -->
+  <section class="cv-section">
+    <div class="cv-section__head">
+      <span class="cv-section__idx">05</span>
+      <h2 class="cv-section__title" data-i18n-en="Contact" data-i18n-zh="è”ç³»æ–¹å¼">Contact</h2>
+      <span class="cv-section__rule"></span>
+    </div>
+    <div class="cv-contact">
+      <a href="https://github.com/Xingchen1224" target="_blank" rel="noopener"><i class="fab fa-github"></i>github.com/Xingchen1224</a>
+      <a href="https://www.linkedin.com/in/xingchen-wang" target="_blank" rel="noopener"><i class="fab fa-linkedin"></i>linkedin.com/in/xingchen-wang</a>
+    </div>
+  </section>
 
----
-
-## Selected Open-Source Projects
-
-Verifiable public work from [github.com/Xingchen1224](https://github.com/Xingchen1224):
-
-- **[opencv_build_as_you_go](https://github.com/Xingchen1224/opencv_build_as_you_go)** —
-  scripts to build OpenCV as simply as possible. *(Shell · CMake)*
-- **[JUCE-Extra-Components](https://github.com/Xingchen1224/JUCE-Extra-Components)** —
-  additional reusable components built on the JUCE framework. *(C++)*
-- **[project_template_cpp](https://github.com/Xingchen1224/project_template_cpp)** —
-  a CMake project template for bootstrapping C++ projects. *(C++ · CMake)*
-
-See the [Projects page](/projects/) for more detail.
-
-<!--
-  ============================================================================
-  TO THE SITE OWNER
-  ----------------------------------------------------------------------------
-  The sections below (Professional Experience, Education, Publications,
-  Languages) could NOT be auto-filled: LinkedIn (linkedin.com) is blocked in
-  the build environment, so your profile could not be read, and no other
-  verifiable public source for your employment history or education was found.
-
-  To avoid publishing fabricated ("mock") details, these sections are left as
-  this comment block instead of invented content. Paste your real information
-  below (uncomment and edit), or provide the details and they can be filled in.
-
-  ## Professional Experience
-  ### <Role Title>
-  **<Company>** · <Location> · <Start> – <End>
-  - <Responsibility / achievement>
-
-  ## Education
-  ### <Degree>
-  **<University>** · <Country> · <Year>
-
-  ## Publications & Talks
-  - <Title> — <Venue>, <Year>
-
-  ## Languages
-  - <Language> — <Proficiency>
-  ============================================================================
--->
-
----
-
-## Contact
-
-| | |
-|---|---|
-| **GitHub** | [github.com/Xingchen1224](https://github.com/Xingchen1224) |
-| **LinkedIn** | [linkedin.com/in/xingchen-wang](https://www.linkedin.com/in/xingchen-wang) |
+</div>


### PR DESCRIPTION
Follow-up to #18. That PR's squash merge only captured the first commit, so these refinements never reached master: English-only (language switch removed), theme/accent settings moved into the masthead, CV projects section removed, and the CV GitHub button made high-contrast. This PR deploys them.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>